### PR TITLE
Add English translation for values/strings.xml

### DIFF
--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,127 @@
+<resources>
+    <string name = "app_name">eRouška</string>
+    <string name = "login_try_again">Try again</string>
+
+    <string name = "notification_title">eRouška is active</string>
+    <string name = "notification_text">You are helping to protect yourself and others</string>
+
+    <string name = "notification_title_error">eRouška not active</string>
+    <string name = "notification_text_bluetooth_disabled">You need to enable Bluetooth for eRouška to work properly</string>
+    <string name = "notification_text_location_disabled">You need to enable Location Services for eRouška to work properly</string>
+    <string name = "notification_text_battery_saver_enabled">You need to turn off the battery saver for eRouška to work properly.</string>
+    <string name = "notification_text_paused">The application is paused. Please remember to resume it.</string>
+    <string name = "notification_action_resume">Resume</string>
+    <string name = "notification_text_resumed">The application is running and collecting anonymous IDs from phones near you.</string>
+    <string name = "notification_action_pause">Pause</string>
+
+    <string name = "notification_action_enable_bluetooth">Enable Bluetooth</string>
+    <string name = "notification_action_enable_location">Turn on Location Services</string>
+    <string name = "notification_action_disable_battery_saver">Turn off battery saver</string>
+    <string name = "foreground_service_channel">Background service</string>
+    <string name = "foreground_service_alert_channel">Important Alerts</string>
+
+    <string name = "help_toolbar_title">How it works</string>
+    <string name = "bluetooth_toolbar_title">Search for devices</string>
+    <string name = "go_back_button">Return to app</string>
+    <string name = "enable_bluetooth_button">Enable Bluetooth</string>
+    <string name = "enable">Enable</string>
+    <string name = "bt_disabled_title">Turn on Bluetooth</string>
+    <string name = "bt_disabled_desc">We can\'t collect IDs from phones near you without Bluetooth.\n\nTurn it on with \"Enable Bluetooth\".</string>
+
+    <string name = "location_disabled_title">Turn on Location Services</string>
+    <string name = "location_disabled_desc">We can\'t collect IDs from phones near you without Location Services.\n\nWe don\'t actually use location data, but we need this permission in Android for running Bluetooth scans. Please turn it on with \"Turn on Location Services\".</string>
+    <string name = "enable_location_button">Enable Location Services</string>
+
+    <string name = "bt_location_disabled_title">Turn on Bluetooth and Location Services</string>
+    <string name = "bt_location_disabled_desc">We can\'t collect IDs from phones near you without Bluetooth and Location Services.\n\nWe don\'t actually use location data, but we need this permission in Android for running Bluetooth scans. Please turn them on with \"Enable BT and Location Services\".</string>
+    <string name = "enable_bt_location_button">Enable BT and Location Services</string>
+
+    <string name = "dashboard_title_running">The app is active</string>
+    <string name = "dashboard_title_paused">The app is paused</string>
+    <string name = "dashboard_body">The app is running in background and is scanning for nearby IDs using Bluetooth. Please don\'t turn off Bluetooth and keep using your phone as usual.</string>
+    <string name = "dashboard_body_paused">The app is currently paused and is no longer scanning for other IDs using Bluetooth.\n\nPlease resume scanning to protect you and your neighborhood. Remember to do this before leaving your home.</string>
+    <string name = "dashboard_secondary">We will contact you at %s when flagged as infected. We will ask you to send an anonymized list of phones, which you can find in My Data.</string>
+    <string name = "bt_enabled_desc">Thank you for helping to fight the spread of coronavirus.\n\nPlease work with the local health authorities to find all the people you have been close to.</string>
+    <string name = "bt_enabled_toolbar_title">Submitted</string>
+    <string name = "share_app">Share app</string>
+    <string name = "upload_data">I was contacted by the local health authorities</string>
+    <string name = "show_my_data">View my data</string>
+    <string name = "pause_app">Pause ID Collection</string>
+    <string name = "start_app">Resume ID Collection</string>
+
+    <string name = "error_ble_unsupported">Your device does not support Bluetooth LE</string>
+    <string name = "permission_onboarding_title">Please allow the app to access Bluetooth and your location</string>
+    <string name = "permission_onboarding_desc">This app does not track or record your location, but we need this permission in Android for running Bluetooth scans.</string>
+    <string name = "permission_onboarding_desc_2">Never turn off Bluetooth for this app to work properly.</string>
+    <string name = "permission_onboarding_desc_minor">This application never sends the collected data by itself. Anonymized data about phones near you will only be sent if you instruct it to do so by pressing the \"Send Data\" button.</string>
+    <string name = "permission_onboarding_toolbar_title">Permissions</string>
+    <string name = "login_toolbar_title">Enable</string>
+    <string name = "help_desc"><![CDATA[<b>The application uses Bluetooth to track phones that are nearby and also have the application installed.</b><br/><br/>It then stores the scanned IDs from other users locally on your phone.<br/><br/><b>Data will only be sent to our servers if you test positive for the infection.</b><br/><br/>Only send data when you\'re instructed to do so by the local health authorities.<br/><br/><b>We generate an ID and pair it with your phone number.</b><br/><br/>You may get contacted by the local health authorities on this phone number if you are in a group of people suspected of being infected with coronavirus.<br/><br/><b>What happens with the IDs I collect from other users near me?</b><br/><br/>The list of collected IDs are stored locally on your phone, and it will be only sent when you instruct the app to do so. You should only do that when instructed by the local authorities<br/><br/><b>This application must keep running in background. However, some phones stop background applications to save battery power. You need to add this app to the list of apps allowed to run in background.</b><br/><br/><a href="%s">Instructions for your phone</a><br/><br/><b>Who runs this app?</b><br/><br/>This app is run by volunteers from several Czech companies under the auspices and supervision of XYZ.]]></string>
+    <string name = "login_desc">Only the local health authorities can contact you on this phone number if a coronavirus infection is confirmed near you.</string>
+    <string name = "login_statement">I have read and, by activation, I agree to the terms of processing personal data during an emergency.</string>
+    <string name = "login_phone_number_input">Phone number (required)</string>
+    <string name = "login_finish_activation">Complete activation</string>
+    <string name = "login_phone_input_hint">Enter your phone number</string>
+    <string name = "login_send">Submit</string>
+    <string name = "login_code_input">Enter the SMS code</string>
+    <string name = "login_phone_input_error">Invalid phone number</string>
+    <string name = "login_code_input_error">Invalid Code</string>
+    <string name = "login_network_error">Error contacting server. Check your data network connection.</string>
+    <string name = "login_too_many_attempts_error">Too many phone number verification attempts. You can try again in a few hours.</string>
+    <string name = "login_session_expired">The code has expired. Submit a new code and enter it in 3 minutes.</string>
+    <string name = "menu_help">Help</string>
+    <string name = "sandbox">Test</string>
+
+    <string name = "my_data_title">My Data</string>
+    <string name = "my_data_description">In this table you will find all records of the IDs of other eRouška users found via Bluetooth. This data does not contain the location nor personal information and will be only sent when you choose to. Records older than %d days are automatically deleted.</string>
+    <string name = "my_data_tab_all_title">All data</string>
+    <string name = "my_data_tab_critical_title">Close Encounters</string>
+
+    <string name = "my_data_column_date">Date</string>
+    <string name = "my_data_column_time">Time</string>
+    <string name = "my_data_column_buid">ID</string>
+    <string name = "my_data_column_rssi">RSSI</string>
+
+    <string name = "permission_rationale_title">Location access permission is required for this app to work properly.</string>
+    <string name = "permission_rationale_body">For more information on why this is needed, please see the Help section.</string>
+    <string name = "permission_rationale_settings">Settings</string>
+    <string name = "permission_rationale_dismiss">Cancel</string>
+    <string name = "welcome_help">How it works</string>
+    <string name = "welcome_activation">Continue activation</string>
+    <string name = "welcome_description"><![CDATA[This app collects anonymous IDs from phones near you.<br/><br/>When a person that has been close to you at some point tests positive, the local health authorities will be able to contact you.<br/><br/>If you test positive for the infection yourself, the local authorities can contact people who have been close to you at some point.]]> </string>
+    <string name = "welcome_title">Protecting myself, protecting others</string>
+    <string name = "login_verify">Verify</string>
+    <string name = "login_verification_code">Verification code</string>
+    <string name = "login_phone_number_sms_sent">We sent an SMS with a verification code to %s.</string>
+    <string name = "login_code_read_automatically">The verification code was automatically pre-filled.</string>
+    <string name = "contacts_title">Contacts</string>
+    <string name = "contacts_suspicion_desc"><b>Do you suspect you might be infected by the coronavirus?</b>\n\nStay at home and contact your health care provider.</string>
+    <string name = "contacts_help_desc"><![CDATA[<b>Do you need help?</b><br/><br/>Please check your local health authorities resources for more information.]]> </string>
+    <string name = "contacts_faq">Frequently Asked Questions</string>
+    <string name = "contacts_important">Important contacts</string>
+    <string name = "contacts_emergency">Call %s</string>
+    <string name = "contacts_improve_desc">Do you have a suggestion to improve this application or a question about how it works?</string>
+    <string name = "contacts_email">Email us</string>
+    <string name = "send_email_chooser">Send email…</string>
+    <string name = "no_emal_client">There is no email client installed.</string>
+    <string name = "default_email_subject">Question about the application</string>
+    <string name = "default_email_address">info@erouska.com</string>
+    <string name = "send_data">Send Data</string>
+    <string name = "upload_successful">The data has been successfully uploaded, and now the local health authorities can access it.</string>
+    <string name = "upload_failed">Failed to upload data. Details: %s</string>
+    <string name = "please_wait_upload">You have already submitted data. You will be able to resubmit data in %d minutes.</string>
+    <string name = "upload_confirmation">Have you been asked by a local health authority to send the data collected by this application?\n\nSubmitted data will be handled by the local health authorities.</string>
+    <string name = "share_app_title">Share the eRouška app</string>
+    <string name = "menu_share_app">Share app</string>
+    <string name = "share_app_text">Hi, I\'m using eRouška. Install it too and let\'s help stop the spread of coronavirus. The app collects anonymous data on nearby phones so that the local health authorities can locate potentially infected people. The more we are, the better it will work. You can find it here %s.</string>
+    <string name = "delete_data_description">Are you sure you want to delete the data collected?\n\nHealth authorities will lose the opportunity to warn people that might have been in contact with you if you get infected.</string>
+    <string name = "delete_data_button">Delete all data</string>
+    <string name = "delete_data">Delete data</string>
+    <string name = "delete_user_desc">Are you sure you want to unregister your phone number?\n\nIf someone that\'s been in contact with you tests positive for the infection, we won\'t be able to contact you.\n\nIf you test positive yourself, we won\'t be able to contact people that might have been in contact with you.\n\nThis action will disable this app on all devices registered with the phone number %s.</string>
+    <string name = "delete_registration">Unregister</string>
+    <string name = "about">About</string>
+    <string name = "yes_send">Yes, send</string>
+    <string name = "upload_error">Failed to upload the collected data to the servers. Please try again later.</string>
+    <string name = "no_internet">Your device does not have an active Internet connection at this moment.</string>
+    <string name = "automatic_logout_warning">Your account no longer exists, you have been signed out.</string>
+</resources>


### PR DESCRIPTION
Given that a significant portion the messages shown in the application
are country-dependent and must set in accordance with the local health
authority policies, this is just intended to be used as a template to
help translators, developers and testers.

It may be convenient to make this the default, and move
values/strings.xml to values-cz/strings.xml, but that's a decision for
the project maintainers.