### PR TITLE
Change Firebase region to europe-west1

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/app/AppConfig.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/AppConfig.kt
@@ -7,6 +7,7 @@ import cz.covid19cz.app.utils.L
 object AppConfig {
 
     const val CSV_VERSION = 3
+    const val FIREBASE_REGION = "europe-west1"
 
     private val firebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
     val collectionSeconds

--- a/app/src/main/kotlin/cz/covid19cz/app/service/PushService.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/service/PushService.kt
@@ -4,6 +4,7 @@ import com.google.firebase.functions.ktx.functions
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import cz.covid19cz.app.AppConfig.FIREBASE_REGION
 import cz.covid19cz.app.db.SharedPrefsRepository
 import cz.covid19cz.app.utils.Auth
 import cz.covid19cz.app.utils.L
@@ -24,7 +25,7 @@ class PushService : FirebaseMessagingService() {
                 "buid" to prefs.getDeviceBuid(),
                 "pushRegistrationToken" to token
             )
-            Firebase.functions("europe-west2").getHttpsCallable("changePushToken").call(data)
+            Firebase.functions(FIREBASE_REGION).getHttpsCallable("changePushToken").call(data)
                 .addOnSuccessListener {
                     L.d("Push token updated")
                 }.addOnFailureListener {

--- a/app/src/main/kotlin/cz/covid19cz/app/ui/confirm/ConfirmationVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/ui/confirm/ConfirmationVM.kt
@@ -8,6 +8,7 @@ import com.google.firebase.storage.StorageException
 import com.google.firebase.storage.ktx.storage
 import com.google.firebase.storage.ktx.storageMetadata
 import cz.covid19cz.app.AppConfig
+import cz.covid19cz.app.AppConfig.FIREBASE_REGION
 import cz.covid19cz.app.db.DatabaseRepository
 import cz.covid19cz.app.db.SharedPrefsRepository
 import cz.covid19cz.app.db.export.CsvExporter
@@ -33,7 +34,7 @@ class ConfirmationVM(
         const val UPLOAD_TIMEOUT_MILLIS = 30000L
     }
 
-    private val functions = Firebase.functions("europe-west2")
+    private val functions = Firebase.functions(FIREBASE_REGION)
     private var exportDisposable: Disposable? = null
     private val storage = Firebase.storage
 

--- a/app/src/main/kotlin/cz/covid19cz/app/ui/login/LoginVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/ui/login/LoginVM.kt
@@ -13,6 +13,7 @@ import com.google.firebase.auth.PhoneAuthProvider
 import com.google.firebase.functions.ktx.functions
 import com.google.firebase.iid.FirebaseInstanceId
 import com.google.firebase.ktx.Firebase
+import cz.covid19cz.app.AppConfig.FIREBASE_REGION
 import cz.covid19cz.app.R
 import cz.covid19cz.app.db.SharedPrefsRepository
 import cz.covid19cz.app.ui.base.BaseVM
@@ -74,7 +75,7 @@ class LoginVM(
     private lateinit var verificationId: String
     private lateinit var resendToken: PhoneAuthProvider.ForceResendingToken
     private val auth: FirebaseAuth = FirebaseAuth.getInstance()
-    private val functions = Firebase.functions("europe-west2")
+    private val functions = Firebase.functions(FIREBASE_REGION)
     private lateinit var phoneNumber: String
 
     init {


### PR DESCRIPTION
We can't make assumptions about Remote config, so there's no need to add the region to it, if it changes in the future we have to support the old regions too.