### PR TITLE
Hide notification badge

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/notifications/CovidNotificationManager.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/notifications/CovidNotificationManager.kt
@@ -33,7 +33,7 @@ class CovidNotificationManager(private val service: CovidService) {
                     SERVICE_CHANNEL_ID,
                     service.getString(R.string.foreground_service_channel),
                     NotificationManager.IMPORTANCE_LOW
-                ),
+                ).apply { setShowBadge(false) },
                 NotificationChannel(
                     ALERT_CHANNEL_ID,
                     service.getString(R.string.foreground_service_alert_channel),


### PR DESCRIPTION
Hides notification badge on Android 8+ for other notifications than alerts