### PR TITLE
Hide keyboad when going back in login flow

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginFragment.kt
@@ -110,7 +110,7 @@ class LoginFragment :
             viewModel.codeEntered(login_verif_code_input.text.toString())
         }
         error_button_back.setOnClickListener {
-            viewModel.backPressed()
+            goBack()
         }
     }
 
@@ -215,9 +215,14 @@ class LoginFragment :
         }
     }
 
+    private fun goBack() {
+        view?.hideKeyboard()
+        viewModel.backPressed()
+    }
+
     override fun onBackPressed(): Boolean {
         return if (viewModel.state.value !is EnterPhoneNumber) {
-            viewModel.backPressed()
+            goBack()
             true
         } else false
     }


### PR DESCRIPTION
Fixes this bug https://trello.com/c/HvgDdEQq/165-zmeny-vo-flow-expirovan%C3%A9ho-sms-k%C3%B3du-and-011203
where the done button would actually try to send the code even when the screen was already in a different state.