### PR TITLE
Make sure UNKNOWN iOS devices are asked for BUID again

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/bt/entity/ScanSession.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/bt/entity/ScanSession.kt
@@ -1,18 +1,20 @@
 package cz.covid19cz.erouska.bt.entity
 
 import arch.livedata.SafeMutableLiveData
+import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.collections.ArrayList
 
 
-class ScanSession(var deviceId: String = DEFAULT_BUID, val mac: String) {
+class ScanSession(var deviceId: String = UNKNOWN_BUID, val mac: String) {
 
     companion object{
-        const val DEFAULT_BUID = "UNKNOWN"
+        const val UNKNOWN_BUID = "UNKNOWN"
     }
 
     private val rssiList = ArrayList<Rssi>()
     val currRssi = SafeMutableLiveData(Int.MAX_VALUE)
+    val lastGattAttempt = SafeMutableLiveData("")
 
     var avgRssi = 0
     var medRssi = 0
@@ -22,11 +24,13 @@ class ScanSession(var deviceId: String = DEFAULT_BUID, val mac: String) {
         get() = rssiList.lastOrNull()?.timestamp ?: 0L
     val rssiCount: Int
         get() = rssiList.size
+    var gattAttemptTimestamp: Long = 0
 
     fun addRssi(rssiVal: Int) {
         val rssi = Rssi(rssiVal)
         rssiList.add(rssi)
         currRssi.postValue(rssiVal)
+        lastGattAttempt.postValue(lastGattAttemptAsString())
     }
 
     fun calculate() {
@@ -60,4 +64,11 @@ class ScanSession(var deviceId: String = DEFAULT_BUID, val mac: String) {
         avgRssi = 0
         medRssi = 0
     }
+
+    fun lastGattAttemptAsString() : String {
+        Date(gattAttemptTimestamp).apply {
+            return SimpleDateFormat("hh:mm:ss").format(this)
+        }
+    }
+
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/bt/entity/ScanSession.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/bt/entity/ScanSession.kt
@@ -6,15 +6,22 @@ import java.util.*
 import kotlin.collections.ArrayList
 
 
-class ScanSession(var deviceId: String = UNKNOWN_BUID, val mac: String) {
+class ScanSession(deviceId: String = UNKNOWN_BUID, val mac: String) {
 
     companion object{
         const val UNKNOWN_BUID = "UNKNOWN"
     }
 
+    var deviceId: String = deviceId
+        set(value) {
+            field = value
+            observableDeviceId.postValue(value)
+        }
+
     private val rssiList = ArrayList<Rssi>()
     val currRssi = SafeMutableLiveData(Int.MAX_VALUE)
     val lastGattAttempt = SafeMutableLiveData("")
+    val observableDeviceId = SafeMutableLiveData(deviceId)
 
     var avgRssi = 0
     var medRssi = 0
@@ -31,6 +38,11 @@ class ScanSession(var deviceId: String = UNKNOWN_BUID, val mac: String) {
         rssiList.add(rssi)
         currRssi.postValue(rssiVal)
         lastGattAttempt.postValue(lastGattAttemptAsString())
+    }
+
+    fun updatedDeviceId(deviceId: String) {
+        this.deviceId = deviceId
+        observableDeviceId.postValue(deviceId)
     }
 
     fun calculate() {
@@ -66,6 +78,9 @@ class ScanSession(var deviceId: String = UNKNOWN_BUID, val mac: String) {
     }
 
     fun lastGattAttemptAsString() : String {
+        if (gattAttemptTimestamp == 0L) {
+            return "N/A (Android)"
+        }
         Date(gattAttemptTimestamp).apply {
             return SimpleDateFormat("hh:mm:ss").format(this)
         }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/sandbox/SandboxVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/sandbox/SandboxVM.kt
@@ -7,10 +7,13 @@ import arch.livedata.SafeMutableLiveData
 import cz.covid19cz.erouska.AppConfig
 import cz.covid19cz.erouska.R
 import cz.covid19cz.erouska.bt.BluetoothRepository
+import cz.covid19cz.erouska.bt.entity.ScanSession
 import cz.covid19cz.erouska.db.DatabaseRepository
 import cz.covid19cz.erouska.db.SharedPrefsRepository
 import cz.covid19cz.erouska.ui.base.BaseVM
 import cz.covid19cz.erouska.ui.dashboard.event.DashboardCommandEvent
+import java.text.SimpleDateFormat
+import java.util.*
 
 class SandboxVM(
     val bluetoothRepository: BluetoothRepository,
@@ -61,7 +64,4 @@ class SandboxVM(
     fun openDbExplorer(){
         navigate(R.id.action_nav_sandbox_to_nav_my_data)
     }
-
-
-
 }

--- a/app/src/main/res/layout/item_scan_result.xml
+++ b/app/src/main/res/layout/item_scan_result.xml
@@ -42,7 +42,7 @@
             android:id="@+id/textBuid"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{item.deviceId}"
+            android:text="@{item.observableDeviceId}"
             android:textColor="@color/textColorSecondary"
             android:textSize="16sp"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_scan_result.xml
+++ b/app/src/main/res/layout/item_scan_result.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto"
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <data>
@@ -41,22 +42,47 @@
             android:id="@+id/textBuid"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/confirm_progress"
+            android:text="@{item.deviceId}"
             android:textColor="@color/textColorSecondary"
             android:textSize="16sp"
-            android:text="@{item.deviceId}"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/confirm_progress"
+            tools:text="BUID" />
 
         <TextView
             android:id="@+id/textCurrentRssi"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/confirm_progress"
+            android:text='@{String.format("RSSI: %d", item.currRssi)}'
             android:textSize="20sp"
             android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/confirm_progress"
             app:textColorResource="@{ColorUtils.INSTANCE.rssiToColor(item.currRssi)}"
-            android:text='@{String.format("RSSI: %d", item.currRssi)}' />
+            tools:text="RSSI: -100" />
+
+        <TextView
+            android:id="@+id/mac"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text='@{String.format("MAC: %s", item.mac)}'
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/textBuid"
+            app:layout_constraintTop_toBottomOf="@+id/textBuid"
+            tools:text="MAC: 12345" />
+
+        <TextView
+            android:id="@+id/gatt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text='@{String.format("Gatt attempt: %s", item.lastGattAttempt)}'
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
+            app:layout_constraintTop_toBottomOf="@+id/mac"
+            app:layout_constraintStart_toStartOf="@+id/mac"
+            tools:text="gatt attempt 00:00:00" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.cardview.widget.CardView>


### PR DESCRIPTION
I noticed that sometimes an iOS devices that failed to send it's BUID over GATT would
stay as UNKNOWN forever. It looks like that calling .close() on the GATT connection
does then in turn skip the onDisconnected callback and that is where we were clearing
the ScanSession.
I changed it so that it actually always sets the timer when disconnecting plus I added a more
aggresssive clearing when scanning is restarted, so that all UNKNOWN iOS devices are
purged from the cache.