### PR TITLE
Don't unbind from service when not connected

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/main/MainActivity.kt
@@ -35,12 +35,15 @@ class MainActivity :
             name: ComponentName,
             client: CustomTabsClient
         ) {
+            connectedToCustomTabsService = true
             client.warmup(0)
         }
 
         override fun onServiceDisconnected(name: ComponentName?) {
+            connectedToCustomTabsService = false
         }
     }
+    private var connectedToCustomTabsService = false
 
     private val serviceStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -118,7 +121,9 @@ class MainActivity :
     }
 
     override fun onStop() {
-        unbindService(customTabsConnection)
+        if (connectedToCustomTabsService) {
+            unbindService(customTabsConnection)
+        }
         super.onStop()
     }
 


### PR DESCRIPTION
Might be a red herring, but I believe this could fix it. Wasn't able to reproduce 😕 
Tried it with Chrome disabled/uninstalled and even with Firefox and it seems to work just fine. 