### PR TITLE
Migrates from BUID broadcasting to TUID broadcasting

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/AppConfig.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/AppConfig.kt
@@ -6,7 +6,7 @@ import cz.covid19cz.erouska.utils.L
 
 object AppConfig {
 
-    const val CSV_VERSION = 3
+    const val CSV_VERSION = 4
     const val FIREBASE_REGION = "europe-west1"
 
     private val firebaseRemoteConfig = FirebaseRemoteConfig.getInstance()

--- a/app/src/main/kotlin/cz/covid19cz/erouska/DI.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/DI.kt
@@ -36,7 +36,7 @@ import org.koin.dsl.module
 
 val viewModelModule = module {
     viewModel { MainVM() }
-    viewModel { SandboxVM(get(), get(), get()) }
+    viewModel { SandboxVM(get(), get()) }
     viewModel { LoginVM(get()) }
     viewModel { WelcomeVM(get(), get()) }
     viewModel { HelpVM() }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/bt/entity/ScanSession.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/bt/entity/ScanSession.kt
@@ -6,13 +6,13 @@ import java.util.*
 import kotlin.collections.ArrayList
 
 
-class ScanSession(deviceId: String = UNKNOWN_BUID, val mac: String) {
+class ScanSession(tuid: String = UNKNOWN_TUID, val mac: String) {
 
     companion object{
-        const val UNKNOWN_BUID = "UNKNOWN"
+        const val UNKNOWN_TUID = "UNKNOWN"
     }
 
-    var deviceId: String = deviceId
+    var deviceId: String = tuid
         set(value) {
             field = value
             observableDeviceId.postValue(value)
@@ -21,7 +21,7 @@ class ScanSession(deviceId: String = UNKNOWN_BUID, val mac: String) {
     private val rssiList = ArrayList<Rssi>()
     val currRssi = SafeMutableLiveData(Int.MAX_VALUE)
     val lastGattAttempt = SafeMutableLiveData("")
-    val observableDeviceId = SafeMutableLiveData(deviceId)
+    val observableDeviceId = SafeMutableLiveData(tuid)
 
     var avgRssi = 0
     var medRssi = 0

--- a/app/src/main/kotlin/cz/covid19cz/erouska/db/AppDatabase.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/db/AppDatabase.kt
@@ -3,7 +3,7 @@ package cz.covid19cz.erouska.db
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [ScanDataEntity::class], version = 7, exportSchema = false)
+@Database(entities = [ScanDataEntity::class], version = 8, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
 
     companion object{

--- a/app/src/main/kotlin/cz/covid19cz/erouska/db/DatabaseRepository.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/db/DatabaseRepository.kt
@@ -11,8 +11,8 @@ interface DatabaseRepository {
     fun getCriticalDesc(): Flowable<List<ScanDataEntity>>
     fun getAllFromTimestamp(timestamp: Long): Single<List<ScanDataEntity>>
     fun add(scanData: ScanDataEntity): Long
-    fun getBuidCount(since: Long): Flowable<Int>
-    fun getCriticalBuidCount(since: Long): Flowable<Int>
+    fun getTuidCount(since: Long): Flowable<Int>
+    fun getCriticalTuidCount(since: Long): Flowable<Int>
     fun delete(scanData: ScanDataEntity)
     fun deleteOldData() : Int
     fun clear()
@@ -34,7 +34,7 @@ class ExpositionRepositoryImpl(private val dao: ScanDataDao) :
     }
 
     override fun add(device: ScanDataEntity): Long {
-        if (device.buid.length == 20) {
+        if (device.tuid.length == 20) {
             return dao.insert(device)
         }
         return 0L
@@ -44,12 +44,12 @@ class ExpositionRepositoryImpl(private val dao: ScanDataDao) :
         return dao.getAllFromTimestamp(timestamp)
     }
 
-    override fun getCriticalBuidCount(since: Long): Flowable<Int> {
-        return dao.getBuidCount(since, AppConfig.criticalExpositionRssi)
+    override fun getCriticalTuidCount(since: Long): Flowable<Int> {
+        return dao.getTuidCount(since, AppConfig.criticalExpositionRssi)
     }
 
-    override fun getBuidCount(since: Long): Flowable<Int> {
-        return dao.getBuidCount(since, -150)
+    override fun getTuidCount(since: Long): Flowable<Int> {
+        return dao.getTuidCount(since, -150)
     }
 
     override fun delete(scanData: ScanDataEntity) {

--- a/app/src/main/kotlin/cz/covid19cz/erouska/db/ExpositionEntity.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/db/ExpositionEntity.kt
@@ -3,13 +3,13 @@ package cz.covid19cz.erouska.db
 import androidx.room.ColumnInfo
 
 data class ExpositionEntity(
-    @ColumnInfo(name = COLUMN_BUID)
-    val buid: String,
+    @ColumnInfo(name = COLUMN_TUID)
+    val tuid: String,
     @ColumnInfo(name = COLUMN_EXPOSITION_TIME)
     val expositionTime: Long
 ){
     companion object{
-        const val COLUMN_BUID = "buid"
+        const val COLUMN_TUID = "tuid"
         const val COLUMN_EXPOSITION_TIME = "expositionTime"
     }
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/db/ScanDataDao.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/db/ScanDataDao.kt
@@ -42,6 +42,6 @@ interface ScanDataDao {
     @Query("DELETE FROM $TABLE_NAME")
     fun clear()
 
-    @Query("SELECT count(DISTINCT ${ScanDataEntity.COLUMN_BUID}) FROM $TABLE_NAME WHERE ${ScanDataEntity.COLUMN_TIMESTAMP_END} > :since AND ${ScanDataEntity.COLUMN_RSSI_MED} >= :rssi")
-    fun getBuidCount(since: Long, rssi : Int) : Flowable<Int>
+    @Query("SELECT count(DISTINCT ${ScanDataEntity.COLUMN_TUID}) FROM $TABLE_NAME WHERE ${ScanDataEntity.COLUMN_TIMESTAMP_END} > :since AND ${ScanDataEntity.COLUMN_RSSI_MED} >= :rssi")
+    fun getTuidCount(since: Long, rssi : Int) : Flowable<Int>
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/db/ScanDataEntity.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/db/ScanDataEntity.kt
@@ -10,8 +10,8 @@ data class ScanDataEntity(
     @ColumnInfo(name = COLUMN_ID)
     @PrimaryKey(autoGenerate = true)
     val id: Long,
-    @ColumnInfo(name = COLUMN_BUID)
-    val buid: String,
+    @ColumnInfo(name = COLUMN_TUID)
+    val tuid: String,
     @ColumnInfo(name = COLUMN_TIMESTAMP_START)
     val timestampStart: Long,
     @ColumnInfo(name = COLUMN_TIMESTAMP_END)
@@ -25,7 +25,7 @@ data class ScanDataEntity(
 ){
     companion object {
         const val COLUMN_ID = "id"
-        const val COLUMN_BUID = "buid"
+        const val COLUMN_TUID = "tuid"
         const val COLUMN_TIMESTAMP_START = "timestampStart"
         const val COLUMN_TIMESTAMP_END = "timestampEnd"
         const val COLUMN_RSSI_AVG = "rssiAvg"
@@ -33,8 +33,8 @@ data class ScanDataEntity(
         const val COLUMN_RSSI_COUNT = "rssiCount"
     }
 
-    fun getMaskedBuid() : String{
-        return "...${buid.substring(14)}"
+    fun getMaskedTuid() : String{
+        return "...${tuid.substring(14)}"
     }
 
     fun getMedDistance() : String{

--- a/app/src/main/kotlin/cz/covid19cz/erouska/db/SharedPrefsRepository.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/db/SharedPrefsRepository.kt
@@ -8,6 +8,8 @@ class SharedPrefsRepository(c : Context) {
 
     companion object{
         const val DEVICE_BUID = "DEVICE_BUID"
+        const val DEVICE_TUIDS = "DEVICE_TUIDS"
+        const val CURRENT_TUID = "CURRENT_TUID"
         const val APP_PAUSED = "preference.app_paused"
         const val LAST_UPLOAD_TIMESTAMP = "preference.last_upload_timestamp"
         const val LAST_DB_CLEANUP_TIMESTAMP = "preference.last_db_cleanup_timestamp"
@@ -19,6 +21,10 @@ class SharedPrefsRepository(c : Context) {
         prefs.edit().putString(DEVICE_BUID, buid).apply()
     }
 
+    fun putDeviceTuids(tuids : List<String>){
+        prefs.edit().putStringSet(DEVICE_TUIDS, tuids.toSet()).apply()
+    }
+
     fun removeDeviceBuid(){
         prefs.edit().remove(DEVICE_BUID).apply()
     }
@@ -26,6 +32,28 @@ class SharedPrefsRepository(c : Context) {
     fun getDeviceBuid() : String?{
         return prefs.getString(DEVICE_BUID, null)
     }
+
+    /**
+     * Returns random element from the list of tuids.
+     * It has an optional parameter which can be used to make sure that no two tuids will be used
+     * twice in a row.
+     */
+    fun getRandomTuid(lastTuid: String? = null) : String?{
+        val stringSet = prefs.getStringSet(DEVICE_TUIDS, emptySet())
+        return stringSet?.let {
+            if (it.size > 1) { // make sure we don't loop in here forever
+                it.random()?.run {
+                    if (this == lastTuid) getRandomTuid(lastTuid) else this
+                }
+            } else {
+                it.firstOrNull()
+            }
+        }
+    }
+
+    fun getCurrentTuid() = prefs.getString(CURRENT_TUID, null)
+
+    fun setCurrentTuid(tuid: String) = prefs.edit().putString(CURRENT_TUID, tuid).apply()
 
     fun setAppPaused(appPaused: Boolean) {
         prefs.edit().putBoolean(APP_PAUSED, appPaused).apply()

--- a/app/src/main/kotlin/cz/covid19cz/erouska/db/export/CsvExporter.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/db/export/CsvExporter.kt
@@ -15,7 +15,7 @@ class CsvExporter(private val repository: DatabaseRepository) {
     companion object {
         // represents the structure of the csv file
         val HEADERS: Array<String> = arrayOf(
-            "buid",
+            "tuid",
             "timestampStart",
             "timestampEnd",
             "avgRssi",
@@ -40,7 +40,7 @@ class CsvExporter(private val repository: DatabaseRepository) {
                 // write entities
                 entities.forEach {
                     csvWriter.write(
-                        it.buid,
+                        it.tuid,
                         it.timestampStart,
                         it.timestampEnd,
                         it.rssiAvg,

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
@@ -13,6 +13,7 @@ import com.google.firebase.auth.PhoneAuthProvider
 import com.google.firebase.functions.ktx.functions
 import com.google.firebase.iid.FirebaseInstanceId
 import com.google.firebase.ktx.Firebase
+import com.google.gson.Gson
 import cz.covid19cz.erouska.AppConfig
 import cz.covid19cz.erouska.AppConfig.FIREBASE_REGION
 import cz.covid19cz.erouska.R
@@ -21,7 +22,6 @@ import cz.covid19cz.erouska.ui.base.BaseVM
 import cz.covid19cz.erouska.utils.DeviceInfo
 import cz.covid19cz.erouska.utils.L
 import cz.covid19cz.erouska.utils.toText
-import org.json.JSONObject
 import java.text.SimpleDateFormat
 
 
@@ -193,8 +193,9 @@ class LoginVM(
                     "pushRegistrationToken" to pushToken
                 )
                 functions.getHttpsCallable("registerBuid").call(data).addOnSuccessListener {
-                    val buid = JSONObject(it.data.toString()).getString("buid")
-                    sharedPrefsRepository.putDeviceBuid(buid)
+                    val response = Gson().fromJson(it.data.toString(), RegistrationResponse::class.java)
+                    sharedPrefsRepository.putDeviceBuid(response.buid)
+                    sharedPrefsRepository.putDeviceTuids(response.tuids)
                     getUser()
                 }.addOnFailureListener {
                     handleError(it)
@@ -208,4 +209,6 @@ class LoginVM(
         val buid = checkNotNull(sharedPrefsRepository.getDeviceBuid())
         mutableState.postValue(SignedIn(fuid, phoneNumber, buid))
     }
+
+    data class RegistrationResponse(val buid: String, val tuids: List<String>)
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/mydata/Event.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/mydata/Event.kt
@@ -6,5 +6,3 @@ sealed class ExportEvent : LiveEvent() {
     data class PleaseWait(val minutes: Int): ExportEvent()
     object Confirmation: ExportEvent()
 }
-
-object ShowDescriptionEvent: LiveEvent()

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/mydata/MyDataFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/mydata/MyDataFragment.kt
@@ -3,6 +3,7 @@ package cz.covid19cz.erouska.ui.mydata
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import arch.adapter.RecyclerLayoutStrategy
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -24,9 +25,6 @@ class MyDataFragment :
         subscribe(ExportEvent.Confirmation::class) {
             navigate(R.id.action_nav_my_data_to_nav_send_data)
         }
-        subscribe(ShowDescriptionEvent::class) {
-            showMessageDialog(getString(R.string.my_data_description, AppConfig.persistDataDays))
-        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -43,6 +41,15 @@ class MyDataFragment :
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.my_data, menu)
         super.onCreateOptionsMenu(menu, inflater)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return if (item.itemId == R.id.data_description) {
+            showMessageDialog(getString(R.string.my_data_description, AppConfig.persistDataDays))
+            true
+        } else {
+            super.onOptionsItemSelected(item)
+        }
     }
 
     private fun showMessageDialog(message: String) {

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/mydata/MyDataVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/mydata/MyDataVM.kt
@@ -23,8 +23,6 @@ class MyDataVM(
     val criticalItems = ObservableArrayList<Any>()
     private val dateFormatter = SimpleDateFormat("d.M.yyyy", Locale.getDefault())
     private val timeFormatter = SimpleDateFormat("HH:mm", Locale.getDefault())
-    val allCount = SafeMutableLiveData(0)
-    val allCriticalCount = SafeMutableLiveData(0)
 
     @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
     fun onCreate() {
@@ -51,14 +49,6 @@ class MyDataVM(
                 criticalItems.add(BatteryOptimizationFooter())
             }
         }
-
-        subscribe(dbRepo.getBuidCount(0), { L.e(it) }) {
-            allCount.value = it
-        }
-
-        subscribe(dbRepo.getCriticalBuidCount(0), { L.e(it) }) {
-            allCriticalCount.value = it
-        }
     }
 
     fun formatDate(timestamp: Long): String {
@@ -76,10 +66,6 @@ class MyDataVM(
         } else {
             publish(ExportEvent.Confirmation)
         }
-    }
-
-    fun showDescription() {
-        publish(ShowDescriptionEvent)
     }
 
     fun openGuide() {

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/sandbox/SandboxVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/sandbox/SandboxVM.kt
@@ -7,22 +7,18 @@ import arch.livedata.SafeMutableLiveData
 import cz.covid19cz.erouska.AppConfig
 import cz.covid19cz.erouska.R
 import cz.covid19cz.erouska.bt.BluetoothRepository
-import cz.covid19cz.erouska.bt.entity.ScanSession
-import cz.covid19cz.erouska.db.DatabaseRepository
 import cz.covid19cz.erouska.db.SharedPrefsRepository
 import cz.covid19cz.erouska.ui.base.BaseVM
 import cz.covid19cz.erouska.ui.dashboard.event.DashboardCommandEvent
-import java.text.SimpleDateFormat
-import java.util.*
 
 class SandboxVM(
     val bluetoothRepository: BluetoothRepository,
-    private val prefs : SharedPrefsRepository,
-    private val repository: DatabaseRepository
+    prefs : SharedPrefsRepository
 ) :
     BaseVM() {
 
     val buid = prefs.getDeviceBuid()
+    val tuid = SafeMutableLiveData(prefs.getCurrentTuid() ?: "")
     val devices = bluetoothRepository.scanResultsList
     val serviceRunning = SafeMutableLiveData(false)
     val power = SafeMutableLiveData(0)

--- a/app/src/main/res/layout/fragment_my_data.xml
+++ b/app/src/main/res/layout/fragment_my_data.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
         <import type="cz.covid19cz.erouska.utils.ColorUtils" />
@@ -17,44 +16,13 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/textStats"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/fragment_padding"
-            android:layout_marginLeft="@dimen/fragment_padding"
-            android:layout_marginRight="@dimen/fragment_padding"
-            android:text="@{@plurals/my_data_count_part_1(AppConfig.INSTANCE.persistDataDays, AppConfig.INSTANCE.persistDataDays) + ` ` + @plurals/my_data_count_part_2(vm.allCount, vm.allCount)}"
-            tools:text="Za posledních 14 dní jste potkali 980 uživatelů aplikace eRouška"
-            android:textSize="16sp"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/descriptionInfo"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
-            android:id="@+id/descriptionInfo"
-            android:layout_width="36dp"
-            android:layout_height="36dp"
-            android:layout_marginEnd="@dimen/fragment_padding"
-            android:src="@drawable/ic_info"
-            android:padding="4dp"
-            android:foreground="@drawable/circle_highlight_selector"
-            android:onClick="@{() -> vm.showDescription()}"
-            app:layout_constraintStart_toEndOf="@id/textStats"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/textStats"
-            app:layout_constraintBottom_toBottomOf="@id/textStats"
-            app:tint="?colorPrimary" />
-
         <com.google.android.material.tabs.TabLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:id="@+id/tabs"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="16dp"
-            app:layout_constraintTop_toBottomOf="@id/textStats"/>
+            app:layout_constraintTop_toTopOf="parent"/>
 
         <include
             android:id="@+id/header"

--- a/app/src/main/res/layout/fragment_sandbox.xml
+++ b/app/src/main/res/layout/fragment_sandbox.xml
@@ -46,12 +46,22 @@
                     tools:text="BUID: 1234567890" />
 
                 <TextView
+                    android:id="@+id/textCurrentTuid"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text='@{String.format("TUID: %s", vm.tuid)}'
+                    android:textSize="16sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/textBuid"
+                    tools:text="TUID: 1234567890" />
+
+                <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text='@{vm.advertisingSupportText}'
                     android:textSize="12sp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/textBuid"
+                    app:layout_constraintTop_toBottomOf="@id/textCurrentTuid"
                     tools:text="Podporuje vysílání" />
 
                 <ProgressBar
@@ -82,7 +92,7 @@
                     android:onClick="@{() -> vm.stop()}"
                     android:text="VYP"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/textBuid" />
+                    app:layout_constraintTop_toBottomOf="@id/textCurrentTuid" />
 
                 <TextView
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_my_data.xml
+++ b/app/src/main/res/layout/item_my_data.xml
@@ -44,17 +44,17 @@
             android:text="@{vm.formatTime(item.timestampEnd)}"
             android:textColor="@color/textColorPrimary"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/textBuid"
+            app:layout_constraintEnd_toStartOf="@id/textTuid"
             app:layout_constraintStart_toEndOf="@id/textDate"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="02:02" />
 
         <TextView
-            android:id="@+id/textBuid"
+            android:id="@+id/textTuid"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:text="@{item.maskedBuid}"
+            android:text="@{item.maskedTuid}"
             android:textColor="@color/textColorPrimary"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/textRssi"
@@ -70,7 +70,7 @@
             android:text='@{String.format("%d dBm",item.rssiMed)}'
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/textBuid"
+            app:layout_constraintStart_toEndOf="@id/textTuid"
             app:layout_constraintTop_toTopOf="parent"
             app:textColorResource="@{ColorUtils.INSTANCE.rssiToColor(item.rssiMed)}"
             tools:text="-70 db" />

--- a/app/src/main/res/layout/item_my_data_header.xml
+++ b/app/src/main/res/layout/item_my_data_header.xml
@@ -37,7 +37,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintStart_toEndOf="@id/textDate"
-            app:layout_constraintEnd_toStartOf="@id/textBuid"
+            app:layout_constraintEnd_toStartOf="@id/textTuid"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             android:gravity="center"
@@ -46,7 +46,7 @@
             android:text="@string/my_data_column_time" />
 
         <TextView
-            android:id="@+id/textBuid"
+            android:id="@+id/textTuid"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintStart_toEndOf="@id/textTime"
@@ -56,13 +56,13 @@
             android:gravity="center"
             android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
             android:textStyle="bold"
-            android:text="@string/my_data_column_buid" />
+            android:text="@string/my_data_column_tuid" />
 
         <TextView
             android:id="@+id/textRssi"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            app:layout_constraintStart_toEndOf="@id/textBuid"
+            app:layout_constraintStart_toEndOf="@id/textTuid"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/menu/my_data.xml
+++ b/app/src/main/res/menu/my_data.xml
@@ -7,4 +7,10 @@
         android:title="@string/delete_data"
         android:visible="true"
         app:showAsAction="always" />
+    <item
+        android:id="@+id/data_description"
+        android:icon="@drawable/ic_help"
+        app:showAsAction="always"
+        app:iconTint="?colorControlNormal"
+        android:title="@string/data_description" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,7 +89,7 @@
 
     <string name="my_data_column_date">Datum</string>
     <string name="my_data_column_time">Čas</string>
-    <string name="my_data_column_buid">ID</string>
+    <string name="my_data_column_tuid">ID</string>
     <string name="my_data_column_rssi">RSSI</string>
 
     <string name="about_title">O\u00A0aplikaci</string>
@@ -161,4 +161,5 @@
     <string name="guide_completed">Pokračovat</string>
     <string name="guide">Návod</string>
     <string name="unexpected_error_text">Nastala neočekávaná chyba. Zkuste to později. Pokud se chyba opakuje delší dobu, konktaktujte naší podporu.</string>
+    <string name="data_description">O zobrazených datech</string>
 </resources>


### PR DESCRIPTION
Background:
Put simply we wanted to make it more secure and private. Periodic rotation of the broadcasted identifier
makes it virtually impossible to track the user over time.

Changes:
The client now receives also a list of TUIDs upon registration and saves those as a set to shared prefs.
Then when broadcasting starts it randomly picks one of those and starts broadcasting it. When broadcasting
gets restarted after a set interval new TUID is chosen from the set. We also never choose the same TUID twice in a row.

- Sandbox now also shows the currently broadcasted TUID
- My data screen doesn't show the bumber of encounters as we are now actually no longer able to track this locally.