### PR TITLE
Fix crash when redirecting to dashboard

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/welcome/WelcomeFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/welcome/WelcomeFragment.kt
@@ -24,7 +24,10 @@ class WelcomeFragment : BaseFragment<FragmentWelcomeBinding, WelcomeVM>(R.layout
                 WelcomeCommandEvent.Command.HELP -> openHelpPage()
             }
         }
+    }
 
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
         if (Auth.isSignedIn()) {
             navigate(R.id.action_nav_welcome_fragment_to_nav_dashboard, null,
                 NavOptions.Builder()

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         versionName = "${VERSION_MAJOR}.${VERSION_MINOR}.${commitCount()}"
 
         versions = [
-                nav                 : '2.3.0-alpha04',
+                nav                 : '2.2.0',
                 lifecycle           : "2.2.0",
                 appcompat           : "1.2.0-alpha03",
                 material            : "1.2.0-alpha05",


### PR DESCRIPTION
https://console.firebase.google.com/u/3/project/daring-leaf-272223/crashlytics/app/android:cz.covid19cz.erouska/issues/50001dc499c2566ea95d1e9fde01d294?time=last-seven-days&sessionId=5E91A00D01F70001033CF66D46CD166D_DNE_0_v2

I wasn't able to reproduce it, but looks like the activity isn't fully created yet.
Moving the redirect to onActivityCreated could help. It's wasteful as at that time the fragments view will already be created but never displayed.

Also trying to downgrade to 2.2.0 which is the last stable version.