### PR TITLE
Add fallback if Battery Saver Settings activity is not found.

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/dashboard/DashboardFragment.kt
@@ -88,15 +88,18 @@ class DashboardFragment : BaseFragment<FragmentPermissionssDisabledBinding, Dash
             .setPositiveButton(R.string.disable_battery_saver)
             { dialog, which ->
                 dialog.dismiss()
-                navigateToBatterySaverSettings()
+                navigateToBatterySaverSettings {
+                    showSnackBar(R.string.battery_saver_settings_not_found)
+                    dialog.dismiss()
+                }
             }
             .setNegativeButton(getString(R.string.confirmation_button_close))
             { dialog, which -> dialog.dismiss() }
             .show()
     }
 
-    private fun navigateToBatterySaverSettings() {
-        val batterySaverIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1 && Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS).resolveActivity(requireContext().packageManager) != null) {
+    private fun navigateToBatterySaverSettings(onBatterySaverNotFound: () -> Unit ) {
+        val batterySaverIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
             Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS)
         } else {
             val intent = Intent()
@@ -106,7 +109,11 @@ class DashboardFragment : BaseFragment<FragmentPermissionssDisabledBinding, Dash
             )
             intent
         }
-        startActivity(batterySaverIntent)
+        try {
+            startActivity(batterySaverIntent)
+        } catch (ex: ActivityNotFoundException) {
+            onBatterySaverNotFound()
+        }
     }
 
     private fun checkIfSignedIn() {

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/dashboard/DashboardFragment.kt
@@ -96,7 +96,7 @@ class DashboardFragment : BaseFragment<FragmentPermissionssDisabledBinding, Dash
     }
 
     private fun navigateToBatterySaverSettings() {
-        val batterySaverIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+        val batterySaverIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1 && Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS).resolveActivity(requireContext().packageManager) != null) {
             Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS)
         } else {
             val intent = Intent()

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/dashboard/DashboardFragment.kt
@@ -90,7 +90,6 @@ class DashboardFragment : BaseFragment<FragmentPermissionssDisabledBinding, Dash
                 dialog.dismiss()
                 navigateToBatterySaverSettings {
                     showSnackBar(R.string.battery_saver_settings_not_found)
-                    dialog.dismiss()
                 }
             }
             .setNegativeButton(getString(R.string.confirmation_button_close))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,4 +162,5 @@
     <string name="guide">Návod</string>
     <string name="unexpected_error_text">Nastala neočekávaná chyba. Zkuste to později. Pokud se chyba opakuje delší dobu, konktaktujte naší podporu.</string>
     <string name="data_description">O zobrazených datech</string>
+    <string name="battery_saver_settings_not_found">Vypněte si prosím spořič baterie ručně.</string>
 </resources>


### PR DESCRIPTION
Add fallback if Battery Saver Settings activity is not found.

On some devices cannot be ACTION_BATTERY_SAVER_SETTINGS open.
In that case, is dialog dismissed and user is notified about it with snack bar.

Resolves: https://console.firebase.google.com/u/2/project/daring-leaf-272223/crashlytics/app/android:cz.covid19cz.erouska/issues/46c184f05e1a7c23ca97b6687fdc2b7c