### PR TITLE
Update unregistration copy for unverified numbers + add new error state to login

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/confirm/DeleteUserFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/confirm/DeleteUserFragment.kt
@@ -10,7 +10,13 @@ import cz.covid19cz.erouska.utils.Auth
 import cz.covid19cz.erouska.utils.formatPhoneNumber
 
 class DeleteUserFragment : ConfirmationFragment() {
-    override val description by lazy { getString(R.string.delete_user_desc, Auth.getPhoneNumber().formatPhoneNumber())}
+    override val description by lazy {
+        if (Auth.isPhoneNumberVerified()) {
+            getString(R.string.delete_user_desc, Auth.getPhoneNumber().formatPhoneNumber())
+        } else {
+            getString(R.string.delete_user_desc_unverified)
+        }
+    }
     override val buttonTextRes = R.string.delete_registration
     override fun confirmedClicked() {
         viewModel.deleteUser()

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
@@ -182,7 +182,6 @@ class LoginVM(
     }
 
     private fun handleError(exception: Exception) {
-        L.e(exception)
         if (exception is FirebaseAuthInvalidCredentialsException) {
             L.d("Error code: ${exception.errorCode}")
         }
@@ -222,6 +221,7 @@ class LoginVM(
                 mutableState.postValue(LoginError(R.string.login_session_expired.toText()))
             }
             else -> {
+                L.e(this)
                 mutableState.postValue(EnterCode(true, phoneNumber))
             }
         }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
@@ -17,10 +17,7 @@ import cz.covid19cz.erouska.AppConfig.FIREBASE_REGION
 import cz.covid19cz.erouska.R
 import cz.covid19cz.erouska.db.SharedPrefsRepository
 import cz.covid19cz.erouska.ui.base.BaseVM
-import cz.covid19cz.erouska.utils.Auth
-import cz.covid19cz.erouska.utils.DeviceInfo
-import cz.covid19cz.erouska.utils.L
-import cz.covid19cz.erouska.utils.toText
+import cz.covid19cz.erouska.utils.*
 import java.text.SimpleDateFormat
 
 
@@ -184,23 +181,49 @@ class LoginVM(
         }
     }
 
-    private fun handleError(e: Exception) {
-        L.e(e)
-        if (e is FirebaseAuthInvalidCredentialsException) {
-            L.d("Error code: ${e.errorCode}")
+    private fun handleError(exception: Exception) {
+        L.e(exception)
+        if (exception is FirebaseAuthInvalidCredentialsException) {
+            L.d("Error code: ${exception.errorCode}")
         }
-        if (e is FirebaseAuthInvalidCredentialsException && e.errorCode == "ERROR_INVALID_PHONE_NUMBER") {
-            mutableState.postValue(EnterPhoneNumber(true))
-        } else if (e is FirebaseAuthInvalidCredentialsException && e.errorCode == "ERROR_INVALID_VERIFICATION_CODE" || e is FirebaseAuthInvalidCredentialsException) {
-            mutableState.postValue(EnterCode(true, phoneNumber))
-        } else if (e is FirebaseAuthInvalidCredentialsException && e.errorCode == "ERROR_TOO_MANY_REQUESTS" || e is FirebaseTooManyRequestsException) {
-            mutableState.postValue(LoginError(R.string.login_too_many_attempts_error.toText()))
-        } else if (e is FirebaseAuthInvalidCredentialsException && e.errorCode == "ERROR_SESSION_EXPIRED") {
-            mutableState.postValue(LoginError(R.string.login_session_expired.toText()))
-        } else if (e is FirebaseNetworkException) {
-            mutableState.postValue(LoginError(R.string.login_network_error.toText()))
-        } else {
-            mutableState.postValue(LoginError(R.string.unexpected_error_text.toText()))
+        when (exception) {
+            is FirebaseAuthInvalidCredentialsException -> {
+                exception.handle()
+            }
+            is FirebaseTooManyRequestsException -> {
+                mutableState.postValue(LoginError(R.string.login_too_many_attempts_error.toText()))
+            }
+            is FirebaseNetworkException -> {
+                mutableState.postValue(LoginError(R.string.login_network_error.toText()))
+            }
+            is FirebaseAuthUserCollisionException -> {
+                mutableState.postValue(LoginError(
+                    R.string.login_number_already_in_use_error.toText(phoneNumber.formatPhoneNumber())
+                ))
+            }
+            else -> {
+                mutableState.postValue(LoginError(R.string.unexpected_error_text.toText()))
+            }
+        }
+    }
+
+    private fun FirebaseAuthInvalidCredentialsException.handle() {
+        when (errorCode) {
+            "ERROR_INVALID_PHONE_NUMBER" -> {
+                mutableState.postValue(EnterPhoneNumber(true))
+            }
+            "ERROR_INVALID_VERIFICATION_CODE" -> {
+                mutableState.postValue(EnterCode(true, phoneNumber))
+            }
+            "ERROR_TOO_MANY_REQUESTS" -> {
+                mutableState.postValue(LoginError(R.string.login_too_many_attempts_error.toText()))
+            }
+            "ERROR_SESSION_EXPIRED" -> {
+                mutableState.postValue(LoginError(R.string.login_session_expired.toText()))
+            }
+            else -> {
+                mutableState.postValue(EnterCode(true, phoneNumber))
+            }
         }
     }
 

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
@@ -201,6 +201,7 @@ class LoginVM(
                 ))
             }
             else -> {
+                L.e(exception)
                 mutableState.postValue(LoginError(R.string.unexpected_error_text.toText()))
             }
         }
@@ -221,7 +222,7 @@ class LoginVM(
                 mutableState.postValue(LoginError(R.string.login_session_expired.toText()))
             }
             else -> {
-                L.e(this)
+                L.e(ErrorCodeException(errorCode, this))
                 mutableState.postValue(EnterCode(true, phoneNumber))
             }
         }
@@ -266,4 +267,6 @@ class LoginVM(
     }
 
     data class RegistrationResponse(val buid: String, val tuids: List<String>)
+
+    class ErrorCodeException(errorCode: String, exception: Exception): Throwable(exception.message + " Error code: $errorCode", exception)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="login_code_input_error">Ověřovací kód není správně zadaný.</string>
     <string name="login_network_error">Chyba při kontaktování serveru. Zkontrolujte připojení k\u00A0datové síti.</string>
     <string name="login_too_many_attempts_error">Moc pokusů o\u00A0ověření telefonního čísla. Znovu to můžete zkusit za několik hodin.</string>
+    <string name="login_number_already_in_use_error">Telefonní číslo nelze použít.\nTelefonní číslo %1$s nemůžete použít, protože jste s ním aktivovali aplikaci na jiném zařízení.</string>
     <string name="login_session_expired">Vypršela platnost ověřovacího kódu. Zkontrolujte telefonní číslo a\u00A0nechte si odeslat nový ověřovací kód.</string>
     <string name="menu_help">Nápověda</string>
 
@@ -136,6 +137,7 @@
     <string name="delete_data_button">Smazat všechna data</string>
     <string name="delete_data">Smazat data</string>
     <string name="delete_user_desc">Opravdu chcete zrušit registraci svého telefonního čísla?\n\nPo zrušení registrace vás nemůžeme kontaktovat v\u00A0případě, že dojde k\u00A0potvrzení nákazy u\u00A0někoho z\u00A0vašeho okolí.\n\nDojde-li k\u00A0potvrzení nákazy u\u00A0vás, nebudeme mít možnost kontaktovat nikoho z\u00A0vašeho okolí.\n\nZrušením registrace dojde k\u00A0vypnutí aplikace ve všech zařízeních registrovaných s\u00A0telefonním číslem %s.</string>
+    <string name="delete_user_desc_unverified">Opravdu chcete zrušit registraci svého telefonního čísla?\n\nDojde-li k potvrzení nákazy u vás, nebudeme mít možnost kontaktovat nikoho z vašeho okolí.\n\nZrušením registrace dojde k vypnutí aplikace pouze v tomto zařízení, protože se vám nepodařilo dokončit aktivaci aplikace včetně ověření telefonního čísla.</string>
     <string name="delete_registration">Zrušit registraci</string>
     <string name="about">O\u00A0aplikaci</string>
     <string name="yes_send">Ano, odeslat</string>


### PR DESCRIPTION
Users can't retroactively verify a number that has been already retroactively verified on another device.
Also when deleting account with unverified number it doesn't delete all the accounts "tied" to that number.