### PR TITLE
Don't trigger notification when screen goes on&off with battery saver on

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/DI.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/DI.kt
@@ -80,7 +80,7 @@ val repositoryModule = module {
 }
 
 val appModule = module {
-    single { LocationStateReceiver() }
+    single { LocationStateReceiver(get()) }
     single { BluetoothStateReceiver() }
     single { BatterSaverStateReceiver() }
     single { LocalBroadcastManager.getInstance(androidApplication()) }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ext/PowerManager.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ext/PowerManager.kt
@@ -1,0 +1,12 @@
+package cz.covid19cz.erouska.ext
+
+import android.os.Build
+import android.os.PowerManager
+
+fun PowerManager.batterySaverRestrictsLocation(): Boolean {
+    return isPowerSaveMode && if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        locationPowerSaveMode == PowerManager.LOCATION_MODE_ALL_DISABLED_WHEN_SCREEN_OFF
+    } else {
+        true
+    }
+}

--- a/app/src/main/kotlin/cz/covid19cz/erouska/receiver/LocationStateReceiver.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/receiver/LocationStateReceiver.kt
@@ -3,14 +3,18 @@ package cz.covid19cz.erouska.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.PowerManager
+import cz.covid19cz.erouska.ext.batterySaverRestrictsLocation
 import cz.covid19cz.erouska.service.CovidService
 import cz.covid19cz.erouska.utils.L
 
-class LocationStateReceiver : BroadcastReceiver(){
+class LocationStateReceiver(private val powerManager: PowerManager) : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
         val action = intent?.action
         L.d("Location state changed")
-        if (action.equals("android.location.PROVIDERS_CHANGED")) {
+        if (action.equals("android.location.PROVIDERS_CHANGED")
+            && !powerManager.batterySaverRestrictsLocation()
+        ) {
             CovidService.update(context)
         }
     }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/service/CovidService.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/service/CovidService.kt
@@ -15,6 +15,7 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import cz.covid19cz.erouska.AppConfig
 import cz.covid19cz.erouska.bt.BluetoothRepository
 import cz.covid19cz.erouska.db.SharedPrefsRepository
+import cz.covid19cz.erouska.ext.batterySaverRestrictsLocation
 import cz.covid19cz.erouska.ext.execute
 import cz.covid19cz.erouska.ext.isLocationEnabled
 import cz.covid19cz.erouska.receiver.BatterSaverStateReceiver
@@ -231,7 +232,7 @@ class CovidService : Service() {
                 servicePaused,
                 btUtils.isBtEnabled(),
                 isLocationEnabled(),
-                batterySaverRestrictsLocation()
+                powerManager.batterySaverRestrictsLocation()
             )
         )
     }
@@ -308,14 +309,6 @@ class CovidService : Service() {
                     it
                 )
             })
-        }
-    }
-
-    private fun batterySaverRestrictsLocation(): Boolean {
-        return powerManager.isPowerSaveMode && if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            powerManager.locationPowerSaveMode == PowerManager.LOCATION_MODE_ALL_DISABLED_WHEN_SCREEN_OFF
-        } else {
-            true
         }
     }
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
@@ -22,6 +22,7 @@ import cz.covid19cz.erouska.utils.DeviceInfo
 import cz.covid19cz.erouska.utils.L
 import cz.covid19cz.erouska.utils.toText
 import java.text.SimpleDateFormat
+import java.util.*
 
 
 class LoginVM(
@@ -104,7 +105,7 @@ class LoginVM(
             }
 
             override fun onTick(millisUntilFinished: Long) {
-                val df = SimpleDateFormat("mm:ss")
+                val df = SimpleDateFormat("mm:ss", Locale.getDefault())
                 remainingTime.postValue(df.format(millisUntilFinished))
             }
 
@@ -112,7 +113,7 @@ class LoginVM(
     private var showVerifyLaterTimer: CountDownTimer =
         object : CountDownTimer(AppConfig.showVerifyLaterTimeoutSeconds * 1000, 1000) {
             override fun onFinish() {
-                publish(ShowVerifyLaterEvent)
+                    publish(ShowVerifyLaterEvent)
             }
 
             override fun onTick(millisUntilFinished: Long) {

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/login/LoginVM.kt
@@ -22,7 +22,6 @@ import cz.covid19cz.erouska.utils.DeviceInfo
 import cz.covid19cz.erouska.utils.L
 import cz.covid19cz.erouska.utils.toText
 import java.text.SimpleDateFormat
-import java.util.*
 
 
 class LoginVM(
@@ -105,7 +104,7 @@ class LoginVM(
             }
 
             override fun onTick(millisUntilFinished: Long) {
-                val df = SimpleDateFormat("mm:ss", Locale.getDefault())
+                val df = SimpleDateFormat("mm:ss")
                 remainingTime.postValue(df.format(millisUntilFinished))
             }
 
@@ -113,7 +112,7 @@ class LoginVM(
     private var showVerifyLaterTimer: CountDownTimer =
         object : CountDownTimer(AppConfig.showVerifyLaterTimeoutSeconds * 1000, 1000) {
             override fun onFinish() {
-                    publish(ShowVerifyLaterEvent)
+                publish(ShowVerifyLaterEvent)
             }
 
             override fun onTick(millisUntilFinished: Long) {


### PR DESCRIPTION
Problem:
Toggling screen state also toggles location state with battery saver on. We listen for
location services state changes so that was what was triggering the notifications.

Change:
Check if battery saver is enabled when the location state broadcast is received.
We can swallow the event in that case as the app should already be in a disabled/error state.

Resolves https://github.com/covid19cz/erouska-android/issues/145