### PR TITLE
Detect Xiaomi device without MiUI (with Android One).

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/utils/BatteryOptimization.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/utils/BatteryOptimization.kt
@@ -19,12 +19,14 @@ object BatteryOptimization {
 
     fun isTutorialNeeded(): Boolean {
         val markdown = getTutorialMarkdown()
-        return AppConfig.showBatteryOptimizationTutorial && markdown != null && !markdown.contains("<!-- do-not-show -->")
+        return AppConfig.showBatteryOptimizationTutorial && markdown != null && !markdown.contains("<!-- do-not-show -->") && !isXiaomiWithAndroidOne()
     }
 
     fun getTutorialMarkdown(): String? {
         return urls[Build.MANUFACTURER.toLowerCase(Locale("cs"))]
     }
+
+    fun isXiaomiWithAndroidOne() = (Build.MANUFACTURER.toLowerCase(Locale("cs")) == "xiaomi" && !isMiUI())
 
     @SuppressLint("PrivateApi")
     fun isMiUI(): Boolean {


### PR DESCRIPTION
Don't show any MiUI battery saver tutorial for these devices.