### PR TITLE
Avoid overlapping buttons on Battery Optimization screen

### DIFF
--- a/app/src/main/res/layout/fragment_battery_optimization.xml
+++ b/app/src/main/res/layout/fragment_battery_optimization.xml
@@ -107,6 +107,13 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent" />
 
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="80dp"
+                    app:layout_constraintTop_toBottomOf="@+id/guide_btn"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    />
+
             </androidx.constraintlayout.widget.ConstraintLayout>
         </ScrollView>
 


### PR DESCRIPTION
Add extra space to avoid overlapping guide by floating button on small screens

Resolves: https://trello.com/c/kC6axqTn/352-and-381-chyb%C3%AD-scrollov%C3%A1n%C3%AD-na-obrazovce-s-potvrzen%C3%ADm-registrace