### PR TITLE
Add autolink extension to markdown parser

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -159,6 +159,7 @@ dependencies {
     // Markdown
     implementation "io.noties.markwon:core:4.3.1"
     implementation 'io.noties.markwon:image-glide:4.3.1'
+    implementation 'com.atlassian.commonmark:commonmark-ext-autolink:0.12.1'
 
     // Others
     implementation "net.sf.supercsv:super-csv:$versions.super_csv"

--- a/app/src/main/kotlin/cz/covid19cz/erouska/utils/Markdown.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/utils/Markdown.kt
@@ -2,13 +2,21 @@ package cz.covid19cz.erouska.utils
 
 import android.content.Context
 import android.widget.TextView
+import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.image.glide.GlideImagesPlugin
+import org.commonmark.ext.autolink.AutolinkExtension
+import org.commonmark.parser.Parser
 
 class Markdown(val context: Context) {
     private val markwon by lazy {
         Markwon.builder(context)
             .usePlugin(GlideImagesPlugin.create(context))
+            .usePlugin(object: AbstractMarkwonPlugin() {
+                override fun configureParser(builder: Parser.Builder) {
+                    builder.extensions(listOf(AutolinkExtension.create()))
+                }
+            })
             .build()
     }
 


### PR DESCRIPTION
Some links are placed directly in the text and for various reasons can't be markdowned 🙂