### PR TITLE
Fix compilation with Java 9+, around XML binding dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,6 +115,16 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.browser:browser:1.2.0"
 
+    // Dependencies for JDK 9+
+    if (JavaVersion.current().ordinal() >= JavaVersion.VERSION_1_9.ordinal()) {
+        kapt "com.sun.xml.bind:jaxb-core:2.3.0.1"
+        kapt "javax.xml.bind:jaxb-api:2.3.1"
+        kapt "com.sun.xml.bind:jaxb-impl:2.3.2"
+
+        annotationProcessor "com.sun.xml.bind:jaxb-core:2.3.0.1"
+        annotationProcessor "javax.xml.bind:jaxb-api:2.3.1"
+    }
+
     // Arch
     implementation project(':arch')
 

--- a/arch/build.gradle
+++ b/arch/build.gradle
@@ -37,6 +37,16 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata:$versions.lifecycle"
     implementation "androidx.lifecycle:lifecycle-common-java8:$versions.lifecycle"
 
+    // Dependencies for JDK 9+
+    if (JavaVersion.current().ordinal() >= JavaVersion.VERSION_1_9.ordinal()) {
+        kapt "com.sun.xml.bind:jaxb-core:2.3.0.1"
+        kapt "javax.xml.bind:jaxb-api:2.3.1"
+        kapt "com.sun.xml.bind:jaxb-impl:2.3.2"
+
+        annotationProcessor "com.sun.xml.bind:jaxb-core:2.3.0.1"
+        annotationProcessor "javax.xml.bind:jaxb-api:2.3.1"
+    }
+
     // Navigation Components
     implementation "androidx.navigation:navigation-fragment-ktx:$versions.nav"
     implementation "androidx.navigation:navigation-ui-ktx:$versions.nav"


### PR DESCRIPTION
Fixes (with Java 11):
android.databinding.annotationprocessor.ProcessDataBinding
  Unable to get public no-arg constructor

References:
https://stackoverflow.com/a/60087174