### PR TITLE
Disable connectable flag

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/bt/BluetoothRepository.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/bt/BluetoothRepository.kt
@@ -372,7 +372,7 @@ class BluetoothRepository(
 
         val settings = AdvertiseSettings.Builder()
             .setAdvertiseMode(AppConfig.advertiseMode)
-            .setConnectable(true)
+            .setConnectable(false)
             .setTimeout(0)
             .setTxPowerLevel(power)
             .build()
@@ -384,6 +384,7 @@ class BluetoothRepository(
             .build()
 
         val scanData = AdvertiseData.Builder()
+            .setIncludeDeviceName(false)
             .addServiceData(parcelUuid, tuid.hexAsByteArray).build()
 
         btManager.adapter?.bluetoothLeAdvertiser?.startAdvertising(


### PR DESCRIPTION
It's currently possible to connect to the device over GATT and download device name, which could
in theory leak user identity if they had their name (or other id) set as the device name.