### PR TITLE
Fix background service starts

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/receiver/ActionsReceiver.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/receiver/ActionsReceiver.kt
@@ -3,6 +3,7 @@ package cz.covid19cz.erouska.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.core.content.ContextCompat
 import cz.covid19cz.erouska.BuildConfig
 import cz.covid19cz.erouska.service.CovidService
 
@@ -19,7 +20,7 @@ class ActionsReceiver : BroadcastReceiver() {
                 context.startService(CovidService.stopService(context))
             }
             ACTION_RESUME -> {
-                context.startService(CovidService.startService(context))
+                ContextCompat.startForegroundService(context, CovidService.startService(context))
             }
         }
     }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/receiver/AutoRestartReceiver.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/receiver/AutoRestartReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Handler
+import androidx.core.content.ContextCompat
 import cz.covid19cz.erouska.R
 import cz.covid19cz.erouska.service.CovidService
 import cz.covid19cz.erouska.utils.L
@@ -36,9 +37,9 @@ class AutoRestartReceiver : BroadcastReceiver() {
 
                 Handler().postDelayed({
                     L.d("Auto-restart of service - starting")
-                    context.startService(
-                        CovidService.startService(context)
-                            .putExtra(EXTRAKEY_START, false)
+                    ContextCompat.startForegroundService(
+                        context,
+                        CovidService.startService(context).putExtra(EXTRAKEY_START, false)
                     )
                 }, 2000);
             }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/main/ShortcutsManager.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/main/ShortcutsManager.kt
@@ -3,6 +3,7 @@ package cz.covid19cz.erouska.ui.main
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.core.content.ContextCompat
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
@@ -28,7 +29,10 @@ class ShortcutsManager(private val context: Context) {
                     context.startService(CovidService.stopService(context))
                 }
                 ShortcutsActions.URL_RESUME -> {
-                    context.startService(CovidService.startService(context))
+                    ContextCompat.startForegroundService(
+                        context,
+                        CovidService.startService(context)
+                    )
                 }
             }
         }


### PR DESCRIPTION
It wasn't using the right method on 8+ Androids.
This switches it to the AppCompact API that takes care of it.