### PR TITLE
Empty view for recent exposures

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/exposure/RecentExposuresFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/exposure/RecentExposuresFragment.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.Observer
 import cz.covid19cz.erouska.AppConfig
 import cz.covid19cz.erouska.R
 import cz.covid19cz.erouska.databinding.FragmentRecentExposuresBinding
+import cz.covid19cz.erouska.ext.hide
+import cz.covid19cz.erouska.ext.show
 import cz.covid19cz.erouska.ui.base.BaseFragment
 import cz.covid19cz.erouska.ui.exposure.event.RecentExposuresEvent
 import kotlinx.android.synthetic.main.fragment_recent_exposures.*
@@ -34,8 +36,15 @@ class RecentExposuresFragment : BaseFragment<FragmentRecentExposuresBinding, Rec
 
     private fun updateState(event: RecentExposuresEvent) {
         when (event) {
-            is RecentExposuresEvent.ExposuresLoadedEvent -> exposureAdapter.updateItems(event.exposures)
+            is RecentExposuresEvent.ExposuresLoadedEvent -> {
+                empty_view.hide()
+                exposures_list.show()
+                exposureAdapter.updateItems(event.exposures)
+            }
+            is RecentExposuresEvent.NoExposuresEvent -> {
+                empty_view.show()
+                exposures_list.hide()
+            }
         }
     }
-
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/exposure/RecentExposuresVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/exposure/RecentExposuresVM.kt
@@ -27,8 +27,11 @@ class RecentExposuresVM(private val exposureNotificationsRepo: ExposureNotificat
                             exposureList.plus(Exposure(dailySummary.daysSinceEpoch.daysSinceEpochToDateString()))
                         }
                         state.postValue(RecentExposuresEvent.ExposuresLoadedEvent(exposureList))
+                    } else {
+                        state.postValue(RecentExposuresEvent.NoExposuresEvent)
                     }
                 }.onFailure {
+                    state.postValue(RecentExposuresEvent.NoExposuresEvent)
                     L.e(it)
                 }
             }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/exposure/event/ExposuresEvent.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/exposure/event/ExposuresEvent.kt
@@ -14,4 +14,5 @@ class ExposuresCommandEvent(val command: Command) : LiveEvent() {
 
 sealed class RecentExposuresEvent {
     data class ExposuresLoadedEvent(val exposures: List<Exposure>) : RecentExposuresEvent()
+    object NoExposuresEvent : RecentExposuresEvent()
 }

--- a/app/src/main/res/layout/fragment_recent_exposures.xml
+++ b/app/src/main/res/layout/fragment_recent_exposures.xml
@@ -1,18 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/exposures_list"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:listitem="@layout/item_recent_exposure"
+            />
+
+        <TextView
+            android:id="@+id/empty_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+            android:text="@string/no_recent_exposures"
+            android:visibility="gone"
+            tools:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_recent_exposure.xml
+++ b/app/src/main/res/layout/item_recent_exposure.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -8,7 +10,7 @@
             type="cz.covid19cz.erouska.ui.exposure.Exposure" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingStart="16dp">
@@ -19,6 +21,7 @@
             android:layout_marginTop="16dp"
             android:layout_marginBottom="16dp"
             android:text="@{ exposure.date }"
+            tools:text="@tools:sample/lorem"
             android:textColor="@color/textColorPrimary"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -136,4 +136,7 @@
     <string name="location_bt_off_body_1">Bez zapnutého Bluetooth a Polohových služeb nemůže eRouška vytvářet seznam ostatních eRoušek ve vašem okolí.</string>
     <string name="location_bt_off_body_2">I když polohová data nijak nevyužíváme, zapněte obě funkce pro správné fungování Bluetooth pomocí tlačítka "Zapnout BT a Polohové služby".</string>
     <string name="location_bt_off_turn_on">Zapnout BT a Polohové služby</string>
+
+    <string name="no_recent_exposures">Žádná riziková setkání</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,5 +122,5 @@
     <string name="location_bt_off_body_2">Even when we don\'t use location data, turn on both functions for correct Bluetooth function using "Enable BT and Location services" button.</string>
     <string name="location_bt_off_turn_on">Enable BT and Location services</string>
 
-    <string name="no_recent_exposures">No recent exposures</string>
+    <string name="no_recent_exposures">No risky encounters</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,4 +121,6 @@
     <string name="location_bt_off_body_1">Without enabled Bluetooth and Location services eRouška can\t create list of other eRouška applications in your vicinity.</string>
     <string name="location_bt_off_body_2">Even when we don\'t use location data, turn on both functions for correct Bluetooth function using "Enable BT and Location services" button.</string>
     <string name="location_bt_off_turn_on">Enable BT and Location services</string>
+
+    <string name="no_recent_exposures">No recent exposures</string>
 </resources>


### PR DESCRIPTION
Simple empty view for recent exposures
Just-in-case scenario. 
The app shouldn't get into this state.

![recent_expo_empty](https://user-images.githubusercontent.com/15926348/93221145-b053cf80-f76d-11ea-841c-bb96dd457111.png)
