### PR TITLE
Fix share link

### DIFF
--- a/app/src/main/res/xml-cs/remote_config_defaults.xml
+++ b/app/src/main/res/xml-cs/remote_config_defaults.xml
@@ -311,7 +311,7 @@
     </entry>
     <entry>
         <key>v2_shareAppDynamicLink</key>
-        <value>https://erouska.cz/app/sdilej</value>
+        <value>https://erouska.cz/app/sdilej/</value>
     </entry>
     <entry>
         <key>v2_chatBotLink</key>

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -342,7 +342,7 @@
     </entry>
     <entry>
         <key>v2_shareAppDynamicLink</key>
-        <value>https://erouska.cz/app/sdilej</value>
+        <value>https://erouska.cz/app/sdilej/</value>
     </entry>
     <entry>
         <key>v2_chatBotLink</key>


### PR DESCRIPTION
When you share thrue the application, the link have dot on the end of them and it's not working. This fix will fix it.