### PR TITLE
Fix download keys

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/exposurenotifications/ExposureNotificationsRepository.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/exposurenotifications/ExposureNotificationsRepository.kt
@@ -224,7 +224,7 @@ class ExposureNotificationsRepository(
             )
     }
 
-    fun isEligibleToDownloadKeys(): Boolean {
-        return System.currentTimeMillis() - prefs.getLastKeyImport() >= AppConfig.keyImportPeriodHours * 60 * 60 * 1000
+    suspend fun isEligibleToDownloadKeys(): Boolean {
+        return isEnabled() && System.currentTimeMillis() - prefs.getLastKeyImport() >= AppConfig.keyImportPeriodHours * 60 * 60 * 1000
     }
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/exposurenotifications/worker/DownloadKeysWorker.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/exposurenotifications/worker/DownloadKeysWorker.kt
@@ -3,7 +3,6 @@ package cz.covid19cz.erouska.exposurenotifications.worker
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import cz.covid19cz.erouska.db.SharedPrefsRepository
 import cz.covid19cz.erouska.exposurenotifications.ExposureNotificationsRepository
 import cz.covid19cz.erouska.net.ExposureServerRepository
 import cz.covid19cz.erouska.utils.Analytics
@@ -20,11 +19,10 @@ class DownloadKeysWorker(
         const val TAG = "DOWNLOAD_KEYS"
     }
 
-    private val exposureNotificationsRepository: ExposureNotificationsRepository by inject()
-    private val serverRepository: ExposureServerRepository by inject()
-
     override suspend fun doWork(): Result {
         try {
+            val exposureNotificationsRepository: ExposureNotificationsRepository by inject()
+            val serverRepository: ExposureServerRepository by inject()
             if (exposureNotificationsRepository.isEligibleToDownloadKeys()) {
                 L.i("Starting download keys worker")
                 Analytics.logEvent(context, Analytics.KEY_EXPORT_DOWNLOAD_STARTED)
@@ -36,10 +34,10 @@ class DownloadKeysWorker(
             } else {
                 L.i("Skipping download keys worker")
             }
+            return Result.success()
         } catch (t : Throwable){
             L.e(t)
-        } finally {
-            return Result.success()
+            return Result.failure()
         }
     }
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/exposurenotifications/worker/SelfCheckerWorker.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/exposurenotifications/worker/SelfCheckerWorker.kt
@@ -19,10 +19,9 @@ class SelfCheckerWorker(
         const val TAG = "SELF_CHECKER"
     }
 
-    private val prefs: SharedPrefsRepository by inject()
-    private val exposureNotificationsRepository: ExposureNotificationsRepository by inject()
-
     override suspend fun doWork(): Result {
+        val prefs: SharedPrefsRepository by inject()
+        val exposureNotificationsRepository: ExposureNotificationsRepository by inject()
         val hour = Calendar.getInstance(Locale.getDefault()).get(Calendar.HOUR_OF_DAY)
         if (hour in 9..19) {
             if (!exposureNotificationsRepository.isEnabled()) {
@@ -32,7 +31,6 @@ class SelfCheckerWorker(
                 LocalNotificationsHelper.showOutdatedDataNotification(context)
             }
         }
-
         return Result.success()
     }
 

--- a/app/src/main/kotlin/cz/covid19cz/erouska/net/ExposureServerRepository.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/net/ExposureServerRepository.kt
@@ -170,18 +170,6 @@ class ExposureServerRepository(
             )
     }
 
-    fun unscheduleKeyDownload() {
-        WorkManager.getInstance(context)
-            .cancelUniqueWork(
-                DownloadKeysWorker.TAG
-            )
-    }
-
-    suspend fun isKeyDownloadScheduled(): Boolean {
-        return WorkManager.getInstance(context).getWorkInfosForUniqueWork(DownloadKeysWorker.TAG)
-            .await().size != 0
-    }
-
     fun deleteFiles() {
         val extractedDir = File(context.cacheDir.path + "/export/")
         extractedDir.deleteRecursively()


### PR DESCRIPTION
This will reschedule key download task on every Dashboard onResume, just like the self checker. Which will immediately launch it, so opening app should always download keys. The check for minimum time between downloads is there, that should prevent downloading keys too often.

I also moved inject() calls to doWork() methods, I found somewhere that it might help with Koin. But I couldn't verify the fix, it's very hard to simulate conditions which the bug is happening (app long time in background). So if we will continue to see the errors, we might have to refactor to Hilt DI. Hilt has a direct support for WorkManager.