### PR TITLE
Fix: unregister broadcast listeners in Dashboard

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/dashboard/DashboardVM.kt
@@ -208,4 +208,10 @@ class DashboardVM(
     fun unregister() {
         FirebaseAuth.getInstance().signOut()
     }
+
+    override fun onCleared() {
+        super.onCleared()
+        app.unregisterReceiver(btReceiver)
+        app.unregisterReceiver(locationReceiver)
+    }
 }


### PR DESCRIPTION
I think you are potentially creating a leak by not unregistering the broadcasts in onCleared(). This would happen if none of the broadcasts is delivered in time and you close the screen. I haven't had a chance to test it (I am located in Slovakia, so it's hard to test). A smoke test would be good to do if you decide to merge. 