### PR TITLE
Upgrade Fabric SDK to Firebase Crashlytics SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.gms.google-services'
-apply plugin: 'io.fabric'
 apply plugin: "androidx.navigation.safeargs.kotlin"
+apply plugin: 'com.google.firebase.crashlytics'
 
 android {
 
@@ -162,8 +162,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-functions-ktx'
     implementation 'com.google.firebase:firebase-storage-ktx'
     implementation 'com.google.firebase:firebase-messaging'
-
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
+    implementation 'com.google.firebase:firebase-crashlytics'
 
     // Play Services
     implementation 'com.google.android.play:core:1.8.0'

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/AboutFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/AboutFragment.kt
@@ -8,7 +8,6 @@ import cz.covid19cz.erouska.BuildConfig
 import cz.covid19cz.erouska.R
 import cz.covid19cz.erouska.databinding.FragmentAboutBinding
 import cz.covid19cz.erouska.ext.showWeb
-import cz.covid19cz.erouska.ui.about.event.VersionEvent
 import cz.covid19cz.erouska.ui.base.BaseFragment
 import cz.covid19cz.erouska.ui.base.UrlEvent
 import cz.covid19cz.erouska.utils.CustomTabHelper
@@ -31,9 +30,6 @@ class AboutFragment :
         subscribe(UrlEvent::class) {
             showWeb(it.url, customTabHelper)
         }
-        subscribe(VersionEvent::class) {
-            L.e(Exception("Crashlytics exception test for version ${BuildConfig.VERSION_NAME}."))
-        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -44,5 +40,9 @@ class AboutFragment :
             getString(R.string.about_tos_content, AppConfig.conditionsOfUseUrl),
             HtmlCompat.FROM_HTML_MODE_LEGACY
         )
+
+        about_version.setOnLongClickListener {
+            throw RuntimeException("Crashlytics exception test for version ${BuildConfig.VERSION_NAME}.")
+        }
     }
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/AboutFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/AboutFragment.kt
@@ -4,14 +4,19 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.text.HtmlCompat
 import cz.covid19cz.erouska.AppConfig
+import cz.covid19cz.erouska.BuildConfig
 import cz.covid19cz.erouska.R
 import cz.covid19cz.erouska.databinding.FragmentAboutBinding
 import cz.covid19cz.erouska.ext.showWeb
+import cz.covid19cz.erouska.ui.about.event.VersionEvent
 import cz.covid19cz.erouska.ui.base.BaseFragment
 import cz.covid19cz.erouska.ui.base.UrlEvent
 import cz.covid19cz.erouska.utils.CustomTabHelper
+import cz.covid19cz.erouska.utils.L
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.android.synthetic.main.fragment_about.*
+import java.lang.Exception
+import java.lang.RuntimeException
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -25,6 +30,9 @@ class AboutFragment :
         super.onCreate(savedInstanceState)
         subscribe(UrlEvent::class) {
             showWeb(it.url, customTabHelper)
+        }
+        subscribe(VersionEvent::class) {
+            L.e(Exception("Crashlytics exception test for version ${BuildConfig.VERSION_NAME}."))
         }
     }
 

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/AboutVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/AboutVM.kt
@@ -2,7 +2,6 @@ package cz.covid19cz.erouska.ui.about
 
 import androidx.hilt.lifecycle.ViewModelInject
 import cz.covid19cz.erouska.AppConfig
-import cz.covid19cz.erouska.ui.about.event.VersionEvent
 import cz.covid19cz.erouska.ui.base.BaseVM
 import cz.covid19cz.erouska.ui.base.UrlEvent
 
@@ -10,9 +9,5 @@ class AboutVM @ViewModelInject constructor() : BaseVM() {
 
     fun tosLinkClicked() {
         publish(UrlEvent(AppConfig.conditionsOfUseUrl))
-    }
-
-    fun versionClicked(){
-        publish(VersionEvent())
     }
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/AboutVM.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/AboutVM.kt
@@ -2,6 +2,7 @@ package cz.covid19cz.erouska.ui.about
 
 import androidx.hilt.lifecycle.ViewModelInject
 import cz.covid19cz.erouska.AppConfig
+import cz.covid19cz.erouska.ui.about.event.VersionEvent
 import cz.covid19cz.erouska.ui.base.BaseVM
 import cz.covid19cz.erouska.ui.base.UrlEvent
 
@@ -11,4 +12,7 @@ class AboutVM @ViewModelInject constructor() : BaseVM() {
         publish(UrlEvent(AppConfig.conditionsOfUseUrl))
     }
 
+    fun versionClicked(){
+        publish(VersionEvent())
+    }
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/event/VersionEvent.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/event/VersionEvent.kt
@@ -1,0 +1,5 @@
+package cz.covid19cz.erouska.ui.about.event
+
+import arch.event.LiveEvent
+
+class VersionEvent : LiveEvent()

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/event/VersionEvent.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/about/event/VersionEvent.kt
@@ -1,5 +1,0 @@
-package cz.covid19cz.erouska.ui.about.event
-
-import arch.event.LiveEvent
-
-class VersionEvent : LiveEvent()

--- a/app/src/main/kotlin/cz/covid19cz/erouska/utils/L.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/utils/L.kt
@@ -18,7 +18,9 @@ object L {
 
     fun i(text: String) {
         val logStrings = createLogStrings(text)
-        FirebaseCrashlytics.getInstance().log("I/${logStrings[0]}: ${logStrings[1]}")
+        if (BuildConfig.DEBUG) {
+            Log.i(logStrings[0], logStrings[1])
+        }
     }
 
     fun w(text: String) {
@@ -31,6 +33,9 @@ object L {
 
     fun e(text: String) {
         val logStrings = createLogStrings(text)
+        if (BuildConfig.DEBUG) {
+            Log.e(logStrings[0], logStrings[1])
+        }
         FirebaseCrashlytics.getInstance().log("E/${logStrings[0]}: ${logStrings[1]}")
     }
 

--- a/app/src/main/kotlin/cz/covid19cz/erouska/utils/L.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/utils/L.kt
@@ -21,6 +21,7 @@ object L {
         if (BuildConfig.DEBUG) {
             Log.i(logStrings[0], logStrings[1])
         }
+        FirebaseCrashlytics.getInstance().log("I/${logStrings[0]}: ${logStrings[1]}")
     }
 
     fun w(text: String) {

--- a/app/src/main/kotlin/cz/covid19cz/erouska/utils/L.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/utils/L.kt
@@ -1,7 +1,7 @@
 package cz.covid19cz.erouska.utils
 
 import android.util.Log
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import cz.covid19cz.erouska.BuildConfig
 
 /**
@@ -18,7 +18,7 @@ object L {
 
     fun i(text: String) {
         val logStrings = createLogStrings(text)
-        Crashlytics.log(Log.INFO, logStrings[0], logStrings[1])
+        FirebaseCrashlytics.getInstance().log("I/${logStrings[0]}: ${logStrings[1]}")
     }
 
     fun w(text: String) {
@@ -26,19 +26,19 @@ object L {
         if (BuildConfig.DEBUG) {
             Log.w(logStrings[0], logStrings[1])
         }
-        Crashlytics.log(Log.WARN, logStrings[0], logStrings[1])
+        FirebaseCrashlytics.getInstance().log("W/${logStrings[0]}: ${logStrings[1]}")
     }
 
     fun e(text: String) {
         val logStrings = createLogStrings(text)
-       Crashlytics.log(Log.ERROR, logStrings[0], logStrings[1])
+        FirebaseCrashlytics.getInstance().log("E/${logStrings[0]}: ${logStrings[1]}")
     }
 
     fun e(throwable: Throwable) {
         if (BuildConfig.DEBUG) {
             Log.e("L", throwable.message, throwable)
         }
-       Crashlytics.logException(throwable)
+        FirebaseCrashlytics.getInstance().recordException(throwable)
     }
 
     private fun createLogStrings(text: String): Array<String> {

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -39,13 +39,13 @@
             app:layout_constraintTop_toBottomOf="@id/about_content" />
 
         <TextView
+            android:id="@+id/about_version"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="#aaa"
             android:text="@{BuildConfig.VERSION_NAME}"
             tools:text="2.0"
             android:clickable="true"
-            android:onClick="@{ () -> vm.versionClicked() }"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             />

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -9,7 +10,7 @@
             type="cz.covid19cz.erouska.ui.about.AboutVM" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:padding="16dp">
@@ -43,8 +44,11 @@
             android:textColor="#aaa"
             android:text="@{BuildConfig.VERSION_NAME}"
             tools:text="2.0"
+            android:clickable="true"
+            android:onClick="@{ () -> vm.versionClicked() }"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"/>
+            app:layout_constraintEnd_toEndOf="parent"
+            />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,6 @@ buildscript {
         jcenter()
         maven { url 'https://dl.bintray.com/kotlin/kotlin-dev' }
         maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
-        maven {
-            url 'https://maven.fabric.io/public'
-        }
     }
 
 
@@ -38,10 +35,10 @@ buildscript {
         classpath "com.android.tools.build:gradle:4.0.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
         classpath 'com.google.gms:google-services:4.3.3'
-        classpath 'io.fabric.tools:gradle:1.31.2'
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.0"
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.12"
         classpath "com.google.dagger:hilt-android-gradle-plugin:2.29.1-alpha"
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.3.0'
     }
 }
 


### PR DESCRIPTION
Fabric SDK needs to upgraded to Firebase Crashlytics SDK no later than November 15, 2020 to continue getting crash reports in the Firebase console.

<img width="1339" alt="Screenshot 2020-09-25 at 11 39 36" src="https://user-images.githubusercontent.com/15926348/94252199-e3435380-ff23-11ea-9116-616d33915c33.png">

https://firebase.google.com/docs/crashlytics/upgrade-sdk?authuser=2&platform=android