### PR TITLE
Prevent stopping already stopped services

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/main/MainActivity.kt
@@ -104,6 +104,7 @@ class MainActivity :
     override fun onStop() {
         if (connectedToCustomTabsService) {
             unbindService(customTabsConnection)
+            connectedToCustomTabsService = false
         }
         super.onStop()
     }


### PR DESCRIPTION
It causes fatal exceptions on some devices
https://console.firebase.google.com/u/2/project/daring-leaf-272223/crashlytics/app/android:cz.covid19cz.erouska/issues/3f79a0b77d361a150a98cd649779d736?time=last-twenty-four-hours&sessionEventKey=5F6BB6B100D600012CA9A48D5E829D80_1454838658163137733