### PR TITLE
Play Services screen auto update

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/base/BaseFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/base/BaseFragment.kt
@@ -8,11 +8,15 @@ import android.provider.Settings
 import android.view.MenuItem
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.pm.PackageInfoCompat
 import androidx.databinding.ViewDataBinding
 import arch.view.BaseArchFragment
 import arch.viewmodel.BaseArchViewModel
+import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.material.snackbar.Snackbar
+import cz.covid19cz.erouska.AppConfig
 import cz.covid19cz.erouska.R
+import cz.covid19cz.erouska.utils.L
 import kotlin.reflect.KClass
 
 
@@ -102,6 +106,22 @@ abstract class BaseFragment<B : ViewDataBinding, VM : BaseArchViewModel>(
     fun requestLocationEnable() {
         val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
         startActivity(intent)
+    }
+
+    fun isPlayServicesObsolete(): Boolean {
+        return try {
+            val current = PackageInfoCompat.getLongVersionCode(
+                requireContext().packageManager.getPackageInfo(
+                    GoogleApiAvailability.GOOGLE_PLAY_SERVICES_PACKAGE,
+                    0
+                )
+            )
+
+            current < AppConfig.minGmsVersionCode
+        } catch (e: Exception) {
+            L.e(e)
+            true
+        }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/dashboard/DashboardFragment.kt
@@ -313,7 +313,7 @@ class DashboardFragment : BaseFragment<FragmentDashboardPlusBinding, DashboardVM
     }
 
     private fun showPlayServicesUpdate() {
-        navigate(R.id.action_nav_dashboard_to_nav_play_services_update)
+        navigate(R.id.action_nav_dashboard_to_nav_play_services_update, Bundle().apply { putBoolean("demo", true) })
     }
 
     private fun showDashboardCards() {

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/update/playservices/UpdatePlayServicesFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/update/playservices/UpdatePlayServicesFragment.kt
@@ -20,6 +20,8 @@ class UpdatePlayServicesFragment :
         const val GMS_STORE_URL = "https://play.google.com/store/apps/details?id=com.google.android.gms"
     }
 
+    private var isDemoMode: Boolean = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -28,15 +30,39 @@ class UpdatePlayServicesFragment :
                 UpdatePlayServicesEvent.Command.PLAY_STORE -> openPlayStore()
             }
         }
+
+        isDemoMode = arguments?.let {
+            UpdatePlayServicesFragmentArgs.fromBundle(it).demo
+        } ?: false
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (!isDemoMode && !isPlayServicesObsolete()) {
+            navController().navigateUp()
+        }
     }
 
     private fun openPlayStore() {
-        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(GMS_STORE_URL)))
+        if (isDemoMode) {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(GMS_STORE_URL)))
+        } else {
+            if (isPlayServicesObsolete()){
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(GMS_STORE_URL)))
+            } else {
+                navController().navigateUp()
+            }
+        }
     }
 
     override fun onBackPressed(): Boolean {
-        activity?.finish()
-        return true
+        return if (isPlayServicesObsolete()) {
+            activity?.finish()
+            true
+        } else {
+            navController().navigateUp()
+            true
+        }
     }
 
 }

--- a/app/src/main/kotlin/cz/covid19cz/erouska/ui/welcome/WelcomeFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/ui/welcome/WelcomeFragment.kt
@@ -64,20 +64,4 @@ class WelcomeFragment :
     private fun showPlayServicesUpdate() {
         navigate(R.id.action_nav_welcome_to_nav_play_services_update)
     }
-
-    private fun isPlayServicesObsolete(): Boolean {
-        return try {
-            val current = PackageInfoCompat.getLongVersionCode(
-                requireContext().packageManager.getPackageInfo(
-                    GoogleApiAvailability.GOOGLE_PLAY_SERVICES_PACKAGE,
-                    0
-                )
-            )
-
-            current < AppConfig.minGmsVersionCode
-        } catch (e: Exception) {
-            L.e(e)
-            true
-        }
-    }
 }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -282,7 +282,10 @@
             android:name="fullscreen"
             android:defaultValue="true"
             app:argType="boolean" />
-
+        <argument
+            android:name="demo"
+            android:defaultValue="false"
+            app:argType="boolean" />
     </fragment>
     <fragment
         android:id="@+id/nav_dashboard_cards"


### PR DESCRIPTION
Demo mode (opened from DEV menu)
- always open the Play Services screen
- always open Google Play

Normal mode
- whenever is the screen refreshed (eg. after the return from Google Play) is the current version of Play Services checked
  * if the app is updated, the screen is closed

- if Play Services are updated and the screen is still shown, the Back button and the Update button redirect the user to the previous screen
- if Play services are outdated the Back button closes the app and the Update button open Google Play