### PR TITLE
Fixed help in night mode - changed highlight color and search view ba…

### DIFF
--- a/app/src/main/kotlin/cz/covid19cz/erouska/utils/Markdown.kt
+++ b/app/src/main/kotlin/cz/covid19cz/erouska/utils/Markdown.kt
@@ -15,7 +15,6 @@ import io.noties.markwon.html.HtmlPlugin
 import io.noties.markwon.image.glide.GlideImagesPlugin
 import io.noties.markwon.inlineparser.InlineProcessor
 import io.noties.markwon.inlineparser.MarkwonInlineParserPlugin
-import io.noties.markwon.inlineparser.OpenBracketInlineProcessor
 import org.commonmark.ext.autolink.AutolinkExtension
 import org.commonmark.node.CustomNode
 import org.commonmark.node.Node
@@ -63,7 +62,7 @@ class Markdown @Inject constructor(
                         .setFactory(
                             SearchedTextNode::class.java
                         ) { _, _ ->
-                            arrayOf(BackgroundColorSpan(context.getColor(R.color.yellow)))
+                            arrayOf(BackgroundColorSpan(context.getColor(R.color.highlight)))
                         }
                 }
             })

--- a/app/src/main/res/layout/search_toolbar.xml
+++ b/app/src/main/res/layout/search_toolbar.xml
@@ -8,7 +8,7 @@
         android:layout_height="?attr/actionBarSize"
         android:layout_gravity="end"
         android:visibility="gone"
-        android:queryBackground="@color/white"
+        android:queryBackground="@color/search_background"
         android:contentDescription="@string/search_hint"
         android:queryHint="@string/search_hint"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -15,4 +15,8 @@
 
     <color name="statusbarColor">@android:color/black</color>
     <bool name="lightStatusBar">false</bool>
+
+    <color name="highlight">#2f80ed</color>
+    <color name="search_background">#000</color>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -14,7 +14,6 @@
     <color name="red">#ff0000</color>
     <color name="redDark">#d81d49</color>
     <color name="green">#8cc23f</color>
-    <color name="yellow">#FFF500</color>
     <color name="orange">#DB7627</color>
 
     <color name="text_color_error_header">#DF6061</color>
@@ -30,5 +29,8 @@
 
     <color name="statusbarColor">#e8e8e8</color>
     <bool name="lightStatusBar">true</bool>
+
+    <color name="highlight">#FFF500</color>
+    <color name="search_background">#fff</color>
 
 </resources>


### PR DESCRIPTION
…ckground color

# Description

Added support for a night mode for search view background and highlight colors

## Screenshots 📸

<details open><summary>Show/Hide content</summary>

<img width="265" alt="Screenshot 2021-02-14 at 22 35 51" src="https://user-images.githubusercontent.com/1065233/107889807-5e2dfa80-6f15-11eb-83c2-a832f802ba8e.png">
<img width="267" alt="Screenshot 2021-02-14 at 22 35 38" src="https://user-images.githubusercontent.com/1065233/107889808-5ff7be00-6f15-11eb-88bd-d649dfc3557a.png">


</details> 

# How Has This Been Tested? 👨‍🔬

Displayed search in dark mode

## What Has Not Been Tested? 🙅🏻‍♂️


# Checklist ✅

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked all visual changes in both light and dark mode.