### PR TITLE
AND-232 Made search highlight color in Dark mode lighter

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -16,7 +16,7 @@
     <color name="statusbarColor">@android:color/black</color>
     <bool name="lightStatusBar">false</bool>
 
-    <color name="highlight">#2f80ed</color>
+    <color name="highlight">#8D2F80ED</color>
     <color name="search_background">#000</color>
 
 </resources>


### PR DESCRIPTION
# Description

Made search highlight color lighter, more transparent, so that links with blue font color can be read.

## Screenshots 📸

<details open><summary>Show/Hide content</summary>

<img width="283" alt="Screenshot 2021-03-15 at 23 44 40" src="https://user-images.githubusercontent.com/1065233/111230853-8da15700-85e8-11eb-8ae1-e8b816d1c4eb.png">

</details> 

# How Has This Been Tested? 👨‍🔬

## What Has Not Been Tested? 🙅🏻‍♂️

# Checklist ✅

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked all visual changes in both light and dark mode.