### PR TITLE
AND-240 Fixed coloring of the switch control

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -28,16 +28,22 @@
         <item name="android:theme">@style/ToolbarTheme</item>
     </style>
 
+    <style name="Widget.App.Switch" parent="Widget.MaterialComponents.CompoundButton.Switch">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.App.Switch</item>
+    </style>
+
+    <style name="ThemeOverlay.App.Switch" parent="">
+        <item name="colorOnSurface">@color/colorPrimaryVariant</item>
+        <item name="colorSurface">@color/gray_light</item>
+        <item name="colorSecondary">@color/colorPrimary</item>
+    </style>
+
     <style name="Divider">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">0.5dp</item>
         <item name="android:background">?android:attr/listDivider</item>
     </style>
-
-    <style name="SwitchStyle" parent="Widget.AppCompat.CompoundButton.Switch">
-        <item name="useMaterialThemeColors">false</item>
-    </style>
-
+    
     <style name="Erouska.Title" parent="TextAppearance.MaterialComponents.Body1">
         <item name="android:textStyle">bold</item>
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,13 +14,12 @@
         <item name="android:statusBarColor">@color/statusbarColor</item>
         <item name="android:windowLightStatusBar">@bool/lightStatusBar</item>
         <item name="android:background">@null</item>
-
+        <item name="switchStyle">@style/Widget.App.Switch</item>
         <item name="toolbarStyle">@style/Toolbar</item>
         <item name="bottomNavigationStyle">@style/Widget.MaterialComponents.BottomNavigationView</item>
         <item name="materialButtonStyle">@style/Button</item>
         <item name="materialButtonOutlinedStyle">@style/OutlinedButton</item>
         <item name="android:actionMenuTextColor">@color/colorPrimary</item>
-        <item name="switchStyle">@style/SwitchStyle</item>
     </style>
 
     <style name="AppTheme.Launchscreen">


### PR DESCRIPTION
# Description

Fixed coloring so that the switch is not so dark in the Dark mode.

## Screenshots 📸

<details open><summary>Show/Hide content</summary>

![Screenshot 2021-03-20 at 1 22 52](https://user-images.githubusercontent.com/1065233/111853325-d0ca3580-891a-11eb-8fe7-a77357b8213b.png)
![Screenshot 2021-03-20 at 1 22 46](https://user-images.githubusercontent.com/1065233/111853326-d162cc00-891a-11eb-845f-1001919c85b7.png)
![Screenshot 2021-03-20 at 1 22 26](https://user-images.githubusercontent.com/1065233/111853328-d162cc00-891a-11eb-8253-8bcddd8dec3e.png)
![Screenshot 2021-03-20 at 1 22 17](https://user-images.githubusercontent.com/1065233/111853329-d1fb6280-891a-11eb-84dc-970b15141c2b.png)


</details> 

# How Has This Been Tested? 👨‍🔬

Displayed in both light and dark mode.

## What Has Not Been Tested? 🙅🏻‍♂️

# Checklist ✅

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked all visual changes in both light and dark mode.