### PR TITLE
AND-242 Button on bottom

### DIFF
--- a/app/src/main/res/layout/fragment_efgs_update.xml
+++ b/app/src/main/res/layout/fragment_efgs_update.xml
@@ -85,20 +85,28 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/legacy_update_checkbox"
                     android:text="@{vm.efgsSupportedCountries()}"
-                    tools:text="@tools:sample/lorem"
+                    tools:text="@tools:sample/lorem"/>
+                
+                <Space
+                    android:id="@+id/legacy_update_space"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="16dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/legacy_update_countries"
+                    app:layout_constraintBottom_toTopOf="@id/legacy_update_button"
                     />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/legacy_update_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="20dp"
-                    android:layout_marginTop="20dp"
+                    android:layout_marginBottom="16dp"
+                    android:text="@string/legacy_update_button_continue"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/legacy_update_countries"
-                    android:text="@string/legacy_update_button_continue" />
+                    app:layout_constraintStart_toStartOf="parent" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
         </ScrollView>


### PR DESCRIPTION
Never floats right below the text in the middle of the screen.

# Description

Glued the button to the bottom so it does not float in the middle of the screen

## Screenshots 📸

<details open><summary>Show/Hide content</summary>

![Screenshot 2021-03-20 at 1 34 25](https://user-images.githubusercontent.com/1065233/111853708-7336e880-891c-11eb-83d9-2300dde00209.png)

</details> 

# How Has This Been Tested? 👨‍🔬

Tested on Android 7 with a very small display and in AS Preview

## What Has Not Been Tested? 🙅🏻‍♂️

Large display on a real phone

# Checklist ✅

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked all visual changes in both light and dark mode.