### PR TITLE
AND-247 Split text so that it can be different on the onboarding screen

### DIFF
--- a/app/src/main/res/layout/fragment_efgs_update.xml
+++ b/app/src/main/res/layout/fragment_efgs_update.xml
@@ -58,7 +58,20 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/legacy_update_header"
                     android:text="@{@string/efgs_boundaries + `\n\n` + @string/efgs_visit(vm.efgsDays)}"
-                    tools:text="@tools:sample/lorem" />
+                    tools:text="@{@string/efgs_boundaries + `\n\n` + @string/efgs_visit(2)}" />
+
+                <TextView
+                    android:id="@+id/legacy_update_body_plus"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textAlignment="textStart"
+                    android:textAppearance="@style/Erouska.Body"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/legacy_update_body"
+                    android:text="@string/efgs_visit_plus"
+                    tools:text="@string/efgs_visit_plus" />
 
                 <com.google.android.material.switchmaterial.SwitchMaterial
                     android:id="@+id/legacy_update_checkbox"
@@ -71,7 +84,7 @@
                     android:checked="@{vm.sharedPrefsRepository.isTraveller()}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/legacy_update_body"
+                    app:layout_constraintTop_toBottomOf="@id/legacy_update_body_plus"
                     />
 
                 <TextView

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -231,7 +231,8 @@
     <string name="efgs_title">Spolupráce se zahraničím</string>
     <string name="efgs_header">Pomozte v boji s COVID-19 i při cestách do zahraničí</string>
     <string name="efgs_boundaries">COVID-19 nezná hranice a díky spolupráci mezi evropskými státy vás eRouška může upozornit na riziková setkání i v případě, že jste se potkali s cizinci, kteří používají podobné aplikace jiných států.</string>
-    <string name="efgs_visit">Povolte upozornění na zahraniční riziková setkání, pokud jste byli v posledních 14 dnech v zahraničí nebo tam jezdíte pravidelně.\n\nNastavení můžete kdykoliv změnit v aplikaci.</string>
+    <string name="efgs_visit">Povolte upozornění na zahraniční riziková setkání, pokud jste byli v posledních %1$s dnech v zahraničí nebo tam jezdíte pravidelně.</string>
+    <string name="efgs_visit_plus">Nastavení můžete kdykoliv změnit v aplikaci.</string>
     <string name="efgs_check">Upozorňovat na zahraniční riziková setkání</string>
     <string name="efgs_usage">Využívání této funkce může způsobit vyšší objem stahovaných dat. Vypněte ji %1$d dní po návratu ze zahraničí.</string>
 

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -230,6 +230,7 @@ Pri používaní aplikácie eRouška nikto nepozná vašu polohu a žiadne iné 
     <string name="efgs_header">Pomôžte v boji s COVID-19 aj pri cestách do zahraničia</string>
     <string name="efgs_boundaries">COVID-19 nepozná hranice a vďaka spolupráci medzi európskymi štátmi vás eRouška môže upozorniť na rizikové stretnutie aj v prípade, že ste sa stretli s cudzincami, ktorí používajú podobné aplikácie iných štátov.</string>
     <string name="efgs_visit">Povoľte si, prosím, Spoluprácu so zahraničím, ak ste boli v posledných %1$d dňoch v niektorej z krajín Európskej únie alebo do nich jazdíte pravidelne. eRouška vás upozorní na možnosť stretnutia s nakazeným chorobou COVID-19.</string>
+    <string name="efgs_visit_plus">Nastavenie môžete kedykoľvek zmeniť v aplikácii.</string>
     <string name="efgs_check">Upozorňovať na zahraničné rizikové stretnutia</string>
     <string name="efgs_usage">Využívanie tejto funkcie môže spôsobiť vyšší objem sťahovaných dát. Vypnite ju %1$d dní po návrate zo zahraničia.</string>
     <string name="efgs_disable_confirmation"><![CDATA[Ochorenie COVID-19 sa môže prejaviť až %1$d dní po stretnutí s nakazenou osobou. Spoluprácu so zahraničím, prosím, vypnite najskôr <b>%1$d dní</b> po návrate.]]></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,7 +224,7 @@ When using eRouška, nobody can collect your location information or other data 
     <string name="efgs_title">Cross-border cooperation</string>
     <string name="efgs_header">Help to fight against COVID-19 when abroad</string>
     <string name="efgs_boundaries">COVID-19 does not respect borders. Thanks to cooperation of EU countries, eRouška can warn you against risk of infection if you encountered foreigners who use similar applications of other countries.</string>
-    <string name="efgs_visit">Please enable notifications about foreign risky encounters if you have been abroad in the past 14 days or you travel regularly.</string>
+    <string name="efgs_visit">Please enable notifications about foreign risky encounters if you have been abroad in the past %1$s days or you travel regularly.</string>
     <string name="efgs_visit_plus">You can change the settings anytime.</string>
     <string name="efgs_check">Notify me about risky encounters abroad</string>
     <string name="efgs_usage">This feature may increase the volume of downloaded data. Disable it %1$d days after you return from abroad.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,7 +224,8 @@ When using eRouška, nobody can collect your location information or other data 
     <string name="efgs_title">Cross-border cooperation</string>
     <string name="efgs_header">Help to fight against COVID-19 when abroad</string>
     <string name="efgs_boundaries">COVID-19 does not respect borders. Thanks to cooperation of EU countries, eRouška can warn you against risk of infection if you encountered foreigners who use similar applications of other countries.</string>
-    <string name="efgs_visit">Please enable notifications about foreign risky encounters if you have been abroad in the past 14 days or you travel regularly.\n\n\nYou can change the settings anytime.</string>
+    <string name="efgs_visit">Please enable notifications about foreign risky encounters if you have been abroad in the past 14 days or you travel regularly.</string>
+    <string name="efgs_visit_plus">You can change the settings anytime.</string>
     <string name="efgs_check">Notify me about risky encounters abroad</string>
     <string name="efgs_usage">This feature may increase the volume of downloaded data. Disable it %1$d days after you return from abroad.</string>
     <string name="efgs_disable_confirmation"><![CDATA[You may not experience COVID-19 symptoms until %1$d days after you met an infected individual. Please do not disable Cross-border cooperation until <b>%1$d days</b> after you return from abroad.]]></string>


### PR DESCRIPTION
Fixed missing string formatter so that efgs days come from app config

# Description

## Screenshots 📸

<details open><summary>Show/Hide content</summary>

![device-2021-03-25-210650](https://user-images.githubusercontent.com/1065233/112536673-0ef9a600-8dae-11eb-9d34-01033cf47125.png)

</details> 

# How Has This Been Tested? 👨‍🔬

## What Has Not Been Tested? 🙅🏻‍♂️

# Checklist ✅

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have checked all visual changes in both light and dark mode.